### PR TITLE
Add achievements screen

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -15,19 +15,53 @@ import Grade2LessonScreen from './screens/Grade2LessonScreen';
 import Grade3Screen from './screens/Grade3Screen';
 import Grade4Screen from './screens/Grade4Screen';
 import SettingsScreen from './screens/SettingsScreen';
+import AchievementsScreen from './screens/AchievementsScreen';
 
 const App = () => {
   const [nav, setNav] = useState({ screen: 'home' });
+  const [achievements, setAchievements] = useState([
+    {
+      id: 'daily',
+      title: 'Daily Learner',
+      description: 'Do a memorisation game each day',
+      icon: 'calendar-check-o',
+      earned: false,
+    },
+    {
+      id: 'set1',
+      title: 'Set 1 Master',
+      description: 'Complete all lessons in Set 1',
+      icon: 'trophy',
+      earned: false,
+    },
+  ]);
+  const [completedLessons, setCompletedLessons] = useState({});
   const goHome = () => setNav({ screen: 'home' });
   const goGrade1 = () => setNav({ screen: 'grade1' });
   const goGrade2 = () => setNav({ screen: 'grade2' });
   const goGrade3 = () => setNav({ screen: 'grade3' });
   const goGrade4 = () => setNav({ screen: 'grade4' });
   const goSettings = () => setNav({ screen: 'settings' });
+  const goAchievements = () => setNav({ screen: 'achievements' });
   const goGrade2Set = (setNumber) => setNav({ screen: 'grade2Set', setNumber });
   const goGrade2Lesson = (lessonNumber) => setNav(prev => ({ screen: 'grade2Lesson', setNumber: prev.setNumber, lessonNumber }));
   const goBackToGrade2Set = () => setNav(prev => ({ screen: 'grade2Set', setNumber: prev.setNumber }));
   const goBackToGrade2 = () => setNav({ screen: 'grade2' });
+
+  const markDaily = () => {
+    setAchievements(a => a.map(ach => ach.id === 'daily' ? { ...ach, earned: true } : ach));
+  };
+
+  const completeLesson = (setNumber, lessonNumber) => {
+    setCompletedLessons(prev => {
+      const lessons = prev[setNumber] || {};
+      const updated = { ...prev, [setNumber]: { ...lessons, [lessonNumber]: true } };
+      if (updated[1] && updated[1][1] && updated[1][2] && updated[1][3]) {
+        setAchievements(a => a.map(ach => ach.id === 'set1' ? { ...ach, earned: true } : ach));
+      }
+      return updated;
+    });
+  };
 
 
   
@@ -35,7 +69,7 @@ const App = () => {
   const renderScreen = () => {
     // Detail screens
     if (nav.screen === 'grade1') return <Grade1Screen onBack={goHome} />;
-    if (nav.screen === 'grade2Lesson') return <Grade2LessonScreen setNumber={nav.setNumber} lessonNumber={nav.lessonNumber} onBack={goBackToGrade2Set} />;
+    if (nav.screen === 'grade2Lesson') return <Grade2LessonScreen setNumber={nav.setNumber} lessonNumber={nav.lessonNumber} onBack={goBackToGrade2Set} onComplete={completeLesson} />;
     if (nav.screen === 'grade2Set') {
       const backHandler = nav.setNumber === 2 ? goHome : goBackToGrade2;
       return <Grade2SetScreen setNumber={nav.setNumber} onLessonSelect={goGrade2Lesson} onBack={backHandler} />;
@@ -43,6 +77,7 @@ const App = () => {
     if (nav.screen === 'grade2') return <Grade2Screen onSetSelect={goGrade2Set} onBack={goHome} />;
     if (nav.screen === 'grade3') return <Grade3Screen onBack={goHome} />;
     if (nav.screen === 'grade4') return <Grade4Screen onBack={goHome} />;
+    if (nav.screen === 'achievements') return <AchievementsScreen achievements={achievements} onDailyPress={markDaily} />;
     if (nav.screen === 'settings') return <SettingsScreen onBack={goHome} />;
     // Default: home screen with tiles
     return (
@@ -92,6 +127,10 @@ const App = () => {
         <TouchableOpacity style={styles.navItem} onPress={goGrade2}>
           <Icon name="book" size={24} color="#333" />
           <Text style={styles.navText}>Lessons</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.navItem} onPress={goAchievements}>
+          <Icon name="trophy" size={24} color="#333" />
+          <Text style={styles.navText}>Badges</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.navItem} onPress={goSettings}>
           <Icon name="cog" size={24} color="#333" />

--- a/screens/AchievementsScreen.jsx
+++ b/screens/AchievementsScreen.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+import Icon from 'react-native-vector-icons/FontAwesome';
+
+const AchievementItem = ({ icon, title, description, earned }) => (
+  <View style={styles.item}>
+    <Icon name={icon} size={32} color={earned ? '#4caf50' : '#ccc'} />
+    <View style={styles.itemText}>
+      <Text style={styles.itemTitle}>{title}</Text>
+      <Text style={styles.itemDesc}>{description}</Text>
+    </View>
+  </View>
+);
+
+const AchievementsScreen = ({ achievements, onDailyPress }) => (
+  <View style={styles.container}>
+    <Text style={styles.title}>Achievements</Text>
+    {achievements.map((ach) => (
+      <AchievementItem
+        key={ach.id}
+        icon={ach.icon}
+        title={ach.title}
+        description={ach.description}
+        earned={ach.earned}
+      />
+    ))}
+    <View style={styles.buttonContainer}>
+      <Button title="Mark Daily Challenge Complete" onPress={onDailyPress} />
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 24,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
+    marginVertical: 8,
+  },
+  itemText: {
+    marginLeft: 16,
+    flex: 1,
+  },
+  itemTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  itemDesc: {
+    fontSize: 14,
+    color: '#666',
+  },
+  buttonContainer: {
+    marginTop: 24,
+    width: '100%',
+  },
+});
+
+export default AchievementsScreen;

--- a/screens/Grade2LessonScreen.jsx
+++ b/screens/Grade2LessonScreen.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 
-const Grade2LessonScreen = ({ setNumber, lessonNumber, onBack }) => {
+const Grade2LessonScreen = ({ setNumber, lessonNumber, onBack, onComplete }) => {
   // Map of specific quotes per set and lesson
   const quoteMap = {
     '1-1': 'Intone, O My servant, the verses of God that have been received by thee, as intoned by them who have drawn nigh unto Him, that the sweetness of thy melody may kindle thine own soul, and attract the hearts of all men.',
@@ -20,6 +20,9 @@ const Grade2LessonScreen = ({ setNumber, lessonNumber, onBack }) => {
     <View style={styles.container}>
       <Text style={styles.title}>Grade 2 - Set {setNumber} Lesson {lessonNumber}</Text>
       <Text style={styles.quote}>{quote}</Text>
+      <View style={styles.buttonContainer}>
+        <Button title="Complete Lesson" onPress={() => onComplete(setNumber, lessonNumber)} />
+      </View>
       <View style={styles.buttonContainer}>
         <Button title="Back" onPress={onBack} />
       </View>


### PR DESCRIPTION
## Summary
- add AchievementsScreen component with basic badge list
- track completed lessons and mark achievements
- add button in Grade2LessonScreen to mark lessons complete
- integrate achievements navigation and daily challenge button

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6853d4a1377083288b384c5e66171bbd