### PR TITLE
Add start screen with sign in and guest flow

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -22,6 +22,7 @@ import SettingsScreen from './screens/SettingsScreen';
 import AchievementsScreen from './screens/AchievementsScreen';
 import TapMissingWordsGame from './screens/TapMissingWordsGame';
 import ProfileSetupScreen from './screens/ProfileSetupScreen';
+import StartScreen from './screens/StartScreen';
 import Splash from './screens/Splash';
 import Grade1SetScreen from './screens/Grade1SetScreen';
 import Grade1LessonScreen from './screens/Grade1LessonScreen';
@@ -30,6 +31,7 @@ const App = () => {
   const [showSplash, setShowSplash] = useState(true);
   const [nav, setNav] = useState({ screen: 'home' });
   const [profile, setProfile] = useState(null);
+  const [showSetup, setShowSetup] = useState(false);
   const [achievements, setAchievements] = useState([
     {
       id: 'daily',
@@ -71,6 +73,10 @@ const App = () => {
   if (showSplash) {
     return <Splash />;
   }
+  const handleStartSignIn = (user) => {
+    saveProfile(user);
+  };
+  const handleContinueGuest = () => setShowSetup(true);
   const goHome = () => setNav({ screen: 'home' });
   const goGrade1 = () => setNav({ screen: 'grade1' });
   const goGrade2 = () => setNav({ screen: 'grade2' });
@@ -136,11 +142,22 @@ const App = () => {
       // ignore errors
     }
     setProfile(null);
+    setShowSetup(false);
   };
 
   // Render the appropriate screen
   const renderScreen = () => {
-    if (!profile) return <ProfileSetupScreen onSave={saveProfile} />;
+    if (!profile) {
+      if (!showSetup) {
+        return (
+          <StartScreen
+            onSignIn={handleStartSignIn}
+            onGuest={handleContinueGuest}
+          />
+        );
+      }
+      return <ProfileSetupScreen onSave={saveProfile} />;
+    }
     // Grade 1 screens: set and lesson
     if (nav.screen === 'grade1') return <Grade1SetScreen onBack={goHome} onLessonSelect={goGrade1Lesson} />;
     if (nav.screen === 'grade1Lesson') return <Grade1LessonScreen lessonNumber={nav.lessonNumber} onBack={goBackToGrade1Set} />;

--- a/screens/StartScreen.jsx
+++ b/screens/StartScreen.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image, Linking } from 'react-native';
+import ThemedButton from '../components/ThemedButton';
+import { signInWithLiquidSpirit } from '../services/authService';
+import splashLogo from '../assets/img/Nuri_Splash.png';
+
+const StartScreen = ({ onSignIn, onGuest }) => {
+  const handleSignIn = async () => {
+    try {
+      const user = await signInWithLiquidSpirit();
+      onSignIn(user);
+    } catch (e) {
+      // handle error - for now we simply log
+      console.error(e);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Nuri</Text>
+      <Image source={splashLogo} style={styles.image} resizeMode="contain" />
+      <View style={styles.buttonContainer}>
+        <ThemedButton
+          title="Sign in with Liquid Spirit"
+          onPress={handleSignIn}
+        />
+      </View>
+      <View style={styles.buttonContainer}>
+        <ThemedButton
+          title="Continue as Guest"
+          onPress={onGuest}
+          style={styles.guestButton}
+          textStyle={styles.guestText}
+        />
+      </View>
+      <View style={styles.linksContainer}>
+        <Text style={styles.link} onPress={() => Linking.openURL('https://example.com/privacy')}>Privacy</Text>
+        <Text style={styles.link}> | </Text>
+        <Text style={styles.link} onPress={() => Linking.openURL('https://example.com/terms')}>Terms of Use</Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  heading: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  image: {
+    width: '80%',
+    height: 200,
+    marginBottom: 32,
+  },
+  buttonContainer: {
+    width: '80%',
+    marginVertical: 8,
+  },
+  guestButton: {
+    backgroundColor: '#f3f3f3',
+  },
+  guestText: {
+    color: '#312783',
+  },
+  linksContainer: {
+    flexDirection: 'row',
+    position: 'absolute',
+    bottom: 32,
+  },
+  link: {
+    color: '#312783',
+    textDecorationLine: 'underline',
+  },
+});
+
+export default StartScreen;

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,0 +1,11 @@
+export const signInWithLiquidSpirit = async () => {
+  try {
+    // Placeholder API call - not functional yet
+    await fetch('https://example.com/api/signin');
+    // Return dummy user data
+    return { name: 'Liquid Spirit User', grade: 1 };
+  } catch (e) {
+    console.error('Sign in failed', e);
+    throw e;
+  }
+};


### PR DESCRIPTION
## Summary
- add `StartScreen` with Liquid Spirit sign in, guest option and links
- add dummy `authService`
- integrate start screen logic in `App`

## Testing
- `yarn test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6854a6167fd8832885d84b46e1faee16