### PR TITLE
Add icons and style for game tiles

### DIFF
--- a/screens/GamesListScreen.jsx
+++ b/screens/GamesListScreen.jsx
@@ -1,6 +1,22 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import {
+  faBookOpen,
+  faHandPointer,
+  faRandom,
+  faArrowRight,
+  faBrain,
+  faBolt,
+  faEye,
+  faFont,
+  faSortAlphaDown,
+  faKeyboard,
+  faUserNinja,
+  faPen,
+} from '@fortawesome/free-solid-svg-icons';
 import { gameIds } from '../games';
+import theme from '../styles/theme';
 
 const titles = {
   practice: 'Practice',
@@ -17,12 +33,30 @@ const titles = {
   fillBlankGame: 'Fill in the Blank',
 };
 
+const iconMap = {
+  practice: faBookOpen,
+  tapGame: faHandPointer,
+  scrambleGame: faRandom,
+  nextWordGame: faArrowRight,
+  memoryGame: faBrain,
+  flashGame: faBolt,
+  revealGame: faEye,
+  firstLetterGame: faFont,
+  letterScrambleGame: faSortAlphaDown,
+  fastTypeGame: faKeyboard,
+  hangmanGame: faUserNinja,
+  fillBlankGame: faPen,
+};
+
 const GamesListScreen = ({ onSelect }) => (
   <View style={styles.container}>
     <Text style={styles.title}>Games</Text>
     <View style={styles.tileContainer}>
       {gameIds.map(id => (
         <TouchableOpacity key={id} style={styles.tile} onPress={() => onSelect(id)}>
+          <View style={styles.iconContainer}>
+            <FontAwesomeIcon icon={iconMap[id]} size={28} color={theme.primaryColor} />
+          </View>
           <Text style={styles.tileText}>{titles[id] || id}</Text>
         </TouchableOpacity>
       ))}
@@ -48,13 +82,30 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   tile: {
-    backgroundColor: '#f0f0f0',
+    backgroundColor: '#fff',
     width: '48%',
     aspectRatio: 1,
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: 16,
     borderRadius: 8,
+    borderWidth: 1,
+    borderColor: theme.borderColor,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  iconContainer: {
+    backgroundColor: theme.neutralLight,
+    borderRadius: 30,
+    padding: 12,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: theme.borderColor,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   tileText: {
     fontSize: 16,


### PR DESCRIPTION
## Summary
- add Font Awesome icon imports to GamesListScreen
- map game ids to icons and render them in each tile
- style tiles with border, background, and shadow to make them pop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a36ec0fc88328a15f829ca0540342