### PR TITLE
Add top bar with back navigation

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -165,13 +165,14 @@ import { UserProvider, UserContext } from './contexts/UserContext';
     lessonNumber: prev.lessonNumber,
   }));
 
-  const goGame = (gameId, quote) => {
+  const goGame = (gameId, quote, fromGames = false) => {
     markGamePlayed();
     setNav(prev => ({
       screen: gameId,
       quote,
       setNumber: prev.setNumber,
       lessonNumber: prev.lessonNumber,
+      fromGames,
     }));
   };
 
@@ -187,7 +188,7 @@ import { UserProvider, UserContext } from './contexts/UserContext';
     if (gameId === 'practice') {
       goPractice(content);
     } else {
-      goGame(gameId, content);
+      goGame(gameId, content, true);
     }
   };
   const goBackToLesson = () => setNav(prev => ({ screen: 'grade2Lesson', setNumber: prev.setNumber, lessonNumber: prev.lessonNumber }));
@@ -366,7 +367,8 @@ import { UserProvider, UserContext } from './contexts/UserContext';
       );
     if (gameScreens[nav.screen]) {
       const GameComponent = gameScreens[nav.screen];
-      return <GameComponent quote={nav.quote} onBack={goBackToLesson} />;
+      const backHandler = nav.fromGames ? goGames : goBackToLesson;
+      return <GameComponent quote={nav.quote} onBack={backHandler} />;
     }
     if (nav.screen === 'grade2Set') {
       const backHandler = nav.setNumber === 2 ? goHome : goBackToGrade2;

--- a/components/GameTopBar.jsx
+++ b/components/GameTopBar.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import themeVariables from '../styles/theme';
+
+const GameTopBar = ({ onBack }) => (
+  <View style={styles.container}>
+    <TouchableOpacity onPress={onBack} style={styles.iconButton}>
+      <FontAwesomeIcon
+        icon={faChevronLeft}
+        size={24}
+        color={themeVariables.primaryColor}
+      />
+    </TouchableOpacity>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  iconButton: {
+    padding: 4,
+  },
+});
+
+export default GameTopBar;

--- a/games/FastTypeGame.jsx
+++ b/games/FastTypeGame.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const FastTypeGame = ({ quote, onBack }) => {
@@ -34,6 +35,7 @@ const FastTypeGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Type It Fast</Text>
       <Text style={styles.description}>Type the quote before time runs out!</Text>
       <Text style={styles.timer}>Time: {time}</Text>

--- a/games/FillBlankTypingGame.jsx
+++ b/games/FillBlankTypingGame.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const FillBlankTypingGame = ({ quote, onBack }) => {
@@ -47,6 +48,7 @@ const FillBlankTypingGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Fill in the Blank</Text>
       <Text style={styles.description}>Type the missing words in the spaces.</Text>
       <Text style={styles.quote}>{display}</Text>

--- a/games/FirstLetterQuizGame.jsx
+++ b/games/FirstLetterQuizGame.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const FirstLetterQuizGame = ({ quote, onBack }) => {
@@ -26,6 +27,7 @@ const FirstLetterQuizGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>First Letter Quiz</Text>
       <Text style={styles.description}>Guess each word using the first letters.</Text>
       <Text style={styles.quote}>{display}</Text>

--- a/games/FlashCardRecallGame.jsx
+++ b/games/FlashCardRecallGame.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const FlashCardRecallGame = ({ quote, onBack }) => {
@@ -43,12 +42,8 @@ const FlashCardRecallGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
-        <TouchableOpacity onPress={onBack} style={styles.headerIcon}>
-          <FontAwesomeIcon icon={faChevronLeft} size={24} color={themeVariables.primaryColor} />
-        </TouchableOpacity>
-        <Text style={styles.title}>Flash Card Recall</Text>
-      </View>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Flash Card Recall</Text>
       <Text style={styles.description}>Look at the quote, then write it from memory.</Text>
       {showQuote ? (
         <Text style={styles.quote}>{quote}</Text>
@@ -127,17 +122,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: themeVariables.primaryColor,
     marginTop: 8,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    alignSelf: 'stretch',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    marginBottom: 8,
-  },
-  headerIcon: {
-    marginRight: 12,
   },
   buttonContainer: {
     width: '80%',

--- a/games/HangmanGame.jsx
+++ b/games/HangmanGame.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const MAX_WRONG = 8;
@@ -35,6 +36,7 @@ const HangmanGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Hangman</Text>
       <Text style={styles.description}>Guess letters to reveal the quote.</Text>
       <Text style={styles.quote}>{masked}</Text>

--- a/games/LetterScrambleGame.jsx
+++ b/games/LetterScrambleGame.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const shuffle = (arr) => {
@@ -58,6 +59,7 @@ const LetterScrambleGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Unscramble Letters</Text>
       <Text style={styles.description}>Unscramble each word. The first letter stays in place.</Text>
       {index < words.length ? (

--- a/games/MemoryMatchGame.jsx
+++ b/games/MemoryMatchGame.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const shuffle = (arr) => arr.sort(() => Math.random() - 0.5);
@@ -49,6 +50,7 @@ const MemoryMatchGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Memory Match</Text>
       <Text style={styles.description}>Find the matching word pairs.</Text>
       <View style={styles.grid}>

--- a/games/NextWordQuizGame.jsx
+++ b/games/NextWordQuizGame.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const shuffle = (arr) => arr.sort(() => Math.random() - 0.5);
@@ -51,6 +52,7 @@ const NextWordQuizGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Pick the next word</Text>
       <Text style={styles.description}>Tap the word that comes next.</Text>
       <Text style={styles.quote}>{words.slice(0, index).join(' ')}</Text>

--- a/games/QuotePracticeScreen.jsx
+++ b/games/QuotePracticeScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const QuotePracticeScreen = ({ quote, onBack }) => {
@@ -49,6 +50,7 @@ const QuotePracticeScreen = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Practice Quote</Text>
       <Text style={styles.description}>Try to type the quote one word at a time.</Text>
       {/* Hint snippet to jog memory */}

--- a/games/RevealWordGame.jsx
+++ b/games/RevealWordGame.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const RevealWordGame = ({ quote, onBack }) => {
@@ -20,6 +21,7 @@ const RevealWordGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Reveal the Quote</Text>
       <Text style={styles.description}>Press the button to show more words.</Text>
       <Text style={styles.quote}>{displayed}</Text>

--- a/games/TapMissingWordsGame.jsx
+++ b/games/TapMissingWordsGame.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const TapMissingWordsGame = ({ quote, onBack }) => {
@@ -54,6 +55,7 @@ const TapMissingWordsGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Fill in the missing words</Text>
       <Text style={styles.description}>Tap the blanks in the right order.</Text>
       <Text style={styles.quote}>{displayWords.join(' ')}</Text>

--- a/games/TapScrambledGame.jsx
+++ b/games/TapScrambledGame.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
+import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
 const shuffle = (arr) => {
@@ -43,6 +44,7 @@ const TapScrambledGame = ({ quote, onBack }) => {
 
   return (
     <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Rebuild the quote</Text>
       <Text style={styles.description}>Tap the words in the correct order.</Text>
       <View style={styles.wordBank}>


### PR DESCRIPTION
## Summary
- create a reusable GameTopBar component
- show the top bar on each game screen
- remember if a game was started from the games list and use that for back
- route back to the games list from the top bar when appropriate

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a3e8a5e0c832885030ac85376b1db