### PR TITLE
Fix repeated word issues in games

### DIFF
--- a/games/NextWordQuizGame.jsx
+++ b/games/NextWordQuizGame.jsx
@@ -24,7 +24,7 @@ const NextWordQuizGame = ({ quote, onBack }) => {
       setOptions([]);
       return;
     }
-    const remaining = w.slice(idx + 1);
+    const remaining = w.slice(idx + 1).filter(word => word !== w[idx]);
     const distractors = [];
     while (distractors.length < 1 && remaining.length > 0) {
       const cand = remaining[Math.floor(Math.random() * remaining.length)];

--- a/games/TapMissingWordsGame.jsx
+++ b/games/TapMissingWordsGame.jsx
@@ -39,7 +39,14 @@ const TapMissingWordsGame = ({ quote, onBack }) => {
       const newDisplay = [...displayWords];
       newDisplay[missingIndices[currentIndex]] = word;
       setDisplayWords(newDisplay);
-      setWordBank(prev => prev.filter(w => w !== word));
+      setWordBank(prev => {
+        const copy = [...prev];
+        const removeIndex = copy.indexOf(word);
+        if (removeIndex !== -1) {
+          copy.splice(removeIndex, 1);
+        }
+        return copy;
+      });
       const nextIndex = currentIndex + 1;
       setCurrentIndex(nextIndex);
       if (nextIndex === missingWords.length) {
@@ -58,9 +65,9 @@ const TapMissingWordsGame = ({ quote, onBack }) => {
       <Text style={styles.description}>Tap the blanks in the right order.</Text>
       <Text style={styles.quote}>{displayWords.join(' ')}</Text>
       <View style={styles.wordBank}>
-        {wordBank.map(word => (
+        {wordBank.map((word, i) => (
           <TouchableOpacity
-            key={word}
+            key={`${word}-${i}`}
             style={styles.wordButton}
             onPress={() => handleWordPress(word)}
           >


### PR DESCRIPTION
## Summary
- fix duplicate handling in TapMissingWordsGame so repeated words work
- filter current word from distractor pool in NextWordQuizGame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a3e5c3ea48328998ffd938d286159