### PR TITLE
Add persistent profile avatar

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -99,7 +99,7 @@ import { UserProvider, UserContext } from './contexts/UserContext';
   useEffect(() => {
     const loadProfile = async () => {
       try {
-        const data = await AsyncStorage.getItem('user');
+        const data = await AsyncStorage.getItem('profile');
         if (data) setProfile(JSON.parse(data));
       } catch (e) {
         // ignore errors

--- a/screens/HomeScreen.jsx
+++ b/screens/HomeScreen.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
 import Avatar from '@flipxyz/react-native-boring-avatars';
@@ -14,7 +14,11 @@ const HomeScreen = ({ profile, achievements, onDailyChallenge, onGoCurrentLesson
       {/* Header: avatar and points */}
       <View style={styles.header}>
         <TouchableOpacity style={styles.profileContainer} onPress={onProfilePress}>
-          <Avatar size={60} name={profile.name} variant="beam" />
+          {profile.avatar ? (
+            <Image source={{ uri: profile.avatar }} style={styles.profileAvatar} />
+          ) : (
+            <Avatar size={60} name={profile.name} variant="beam" />
+          )}
           <View style={styles.profileTextContainer}>
             <Text style={styles.profileName}>{profile.name}</Text>
             <Text style={styles.profileGrade}>Grade {profile.grade || 'N/A'}</Text>
@@ -81,6 +85,11 @@ const styles = StyleSheet.create({
   },
   profileTextContainer: {
     marginLeft: 12,
+  },
+  profileAvatar: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
   },
   profileName: {
     fontSize: 20,

--- a/screens/ProfileSetupScreen.jsx
+++ b/screens/ProfileSetupScreen.jsx
@@ -13,6 +13,7 @@ const ProfileSetupScreen = ({ onSave }) => {
   const [showDropdown, setShowDropdown] = useState(false);
   const [avatarSeed, setAvatarSeed] = useState(Math.random().toString());
   const [avatarUri, setAvatarUri] = useState(null);
+  const [avatarData, setAvatarData] = useState(null);
   const grades = ['1', '2', '3', '4'];
 
   const save = () => {
@@ -21,13 +22,20 @@ const ProfileSetupScreen = ({ onSave }) => {
     const gradeNum = parseInt(grade, 10);
     const fullName = `${firstName} ${lastName}`;
     // Pass both names and combined name for compatibility
-    onSave({ name: fullName, firstName, lastName, grade: isNaN(gradeNum) ? '' : gradeNum });
+    onSave({
+      name: fullName,
+      firstName,
+      lastName,
+      grade: isNaN(gradeNum) ? '' : gradeNum,
+      avatar: avatarData,
+    });
   };
 
   const pickImage = async () => {
     const result = await launchImageLibrary({
       mediaType: 'photo',
       quality: 1,
+      includeBase64: true,
     });
 
     if (result.didCancel) return;
@@ -38,6 +46,10 @@ const ProfileSetupScreen = ({ onSave }) => {
     const asset = result.assets && result.assets[0];
     if (asset && asset.uri) {
       setAvatarUri(asset.uri);
+      if (asset.base64) {
+        const type = asset.type || 'image/jpeg';
+        setAvatarData(`data:${type};base64,${asset.base64}`);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- allow saving of avatar image on profile setup
- load persisted profile including avatar
- display saved avatar on the home screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a3f1353d483289d4fad87beac8d94