### PR TITLE
Replace text input games with button interactions

### DIFF
--- a/games/FastTypeGame.jsx
+++ b/games/FastTypeGame.jsx
@@ -1,52 +1,86 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, TextInput, StyleSheet } from 'react-native';
-import ThemedButton from '../components/ThemedButton';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
 
+const shuffle = (arr) => arr.sort(() => Math.random() - 0.5);
+
 const FastTypeGame = ({ quote, onBack }) => {
   const [time, setTime] = useState(30);
-  const [input, setInput] = useState('');
+  const [words, setWords] = useState([]);
+  const [index, setIndex] = useState(0);
+  const [options, setOptions] = useState([]);
   const [message, setMessage] = useState('');
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    setTime(30);
-    setInput('');
+    const w = quote.split(/\s+/);
+    setWords(w);
+    setIndex(0);
     setMessage('');
+    setTime(30);
+    generateOptions(w, 0);
     const timer = setInterval(() => {
       setTime((t) => t - 1);
     }, 1000);
     return () => clearInterval(timer);
   }, [quote]);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (time === 0 && message === '') {
-      check();
+      setMessage("Time's up!");
+      setOptions([]);
     }
   }, [time]);
 
-  const check = () => {
-    if (input.trim().toLowerCase() === quote.trim().toLowerCase()) {
-      setMessage('Great job!');
+  const generateOptions = (w, idx) => {
+    if (idx >= w.length) {
+      setOptions([]);
+      return;
+    }
+    const remaining = w.filter((_, i) => i !== idx);
+    const distractors = [];
+    while (distractors.length < 3 && remaining.length > 0) {
+      const cand = remaining[Math.floor(Math.random() * remaining.length)];
+      if (!distractors.includes(cand)) distractors.push(cand);
+    }
+    while (distractors.length < 3) {
+      distractors.push(w[Math.floor(Math.random() * w.length)]);
+    }
+    setOptions(shuffle([w[idx], ...distractors]));
+  };
+
+  const handleSelect = (word) => {
+    if (time === 0) return;
+    if (word === words[index]) {
+      const next = index + 1;
+      setIndex(next);
+      if (next === words.length) {
+        setMessage('Great job!');
+        setOptions([]);
+      } else {
+        setMessage('');
+        generateOptions(words, next);
+      }
     } else {
-      setMessage("Time's up!");
+      setMessage('Try again');
     }
   };
 
   return (
     <View style={styles.container}>
       <GameTopBar onBack={onBack} />
-      <Text style={styles.title}>Type It Fast</Text>
-      <Text style={styles.description}>Type the quote before time runs out!</Text>
+      <Text style={styles.title}>Tap It Fast</Text>
+      <Text style={styles.description}>Tap each word in order before time runs out!</Text>
       <Text style={styles.timer}>Time: {time}</Text>
-      <TextInput
-        style={styles.input}
-        value={input}
-        onChangeText={setInput}
-        placeholder="Type the quote"
-        multiline
-      />
-      <ThemedButton title="Submit" onPress={check} />
+      <View style={styles.options}>
+        {options.map((o, i) => (
+          <TouchableOpacity key={`${o}-${i}`} style={styles.optionButton} onPress={() => handleSelect(o)}>
+            <Text style={styles.optionText}>{o}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
       {message !== '' && <Text style={styles.message}>{message}</Text>}
     </View>
   );
@@ -73,22 +107,29 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginBottom: 8,
   },
-  input: {
+  options: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  optionButton: {
+    backgroundColor: themeVariables.whiteColor,
     borderWidth: 1,
-    borderColor: '#ccc',
-    padding: 8,
-    marginBottom: 8,
-    width: '80%',
+    borderColor: themeVariables.primaryColor,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    margin: 4,
+    borderRadius: themeVariables.borderRadiusPill,
+  },
+  optionText: {
     fontSize: 18,
+    color: themeVariables.primaryColor,
+    fontWeight: 'bold',
   },
   message: {
     fontSize: 18,
     color: themeVariables.primaryColor,
     marginVertical: 8,
-  },
-  buttonContainer: {
-    width: '80%',
-    marginTop: 16,
   },
 });
 

--- a/games/FillBlankTypingGame.jsx
+++ b/games/FillBlankTypingGame.jsx
@@ -1,16 +1,18 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, StyleSheet } from 'react-native';
-import ThemedButton from '../components/ThemedButton';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import GameTopBar from '../components/GameTopBar';
 import themeVariables from '../styles/theme';
+
+const shuffle = (arr) => arr.sort(() => Math.random() - 0.5);
 
 const FillBlankTypingGame = ({ quote, onBack }) => {
   const [words, setWords] = useState([]);
   const [missing, setMissing] = useState([]);
   const [current, setCurrent] = useState(0);
-  const [input, setInput] = useState('');
+  const [options, setOptions] = useState([]);
   const [message, setMessage] = useState('');
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const arr = quote.split(' ');
     const num = Math.min(3, Math.max(1, Math.floor(arr.length / 8)));
@@ -20,19 +22,43 @@ const FillBlankTypingGame = ({ quote, onBack }) => {
       if (!indices.includes(idx)) indices.push(idx);
     }
     setWords(arr);
-    setMissing(indices.sort((a, b) => a - b));
+    const sorted = indices.sort((a, b) => a - b);
+    setMissing(sorted);
     setCurrent(0);
-    setInput('');
     setMessage('');
+    generateOptions(arr, sorted, 0);
   }, [quote]);
 
-  const handleSubmit = () => {
+  const generateOptions = (arr, indices, idx) => {
+    if (idx >= indices.length) {
+      setOptions([]);
+      return;
+    }
+    const word = arr[indices[idx]];
+    const remaining = arr.filter((w, i) => !indices.includes(i) && w !== word);
+    const distractors = [];
+    while (distractors.length < 3 && remaining.length > 0) {
+      const cand = remaining[Math.floor(Math.random() * remaining.length)];
+      if (!distractors.includes(cand)) distractors.push(cand);
+    }
+    while (distractors.length < 3) {
+      distractors.push(arr[Math.floor(Math.random() * arr.length)]);
+    }
+    setOptions(shuffle([word, ...distractors]));
+  };
+
+  const handleSelect = (word) => {
     const idx = missing[current];
-    if (words[idx].replace(/[^a-zA-Z]/g, '').toLowerCase() === input.trim().toLowerCase()) {
+    if (word === words[idx]) {
       const next = current + 1;
       setCurrent(next);
-      setInput('');
-      setMessage(next === missing.length ? 'Great job!' : 'Correct!');
+      if (next === missing.length) {
+        setMessage('Great job!');
+        setOptions([]);
+      } else {
+        setMessage('Correct!');
+        generateOptions(words, missing, next);
+      }
     } else {
       setMessage('Try again');
     }
@@ -50,17 +76,15 @@ const FillBlankTypingGame = ({ quote, onBack }) => {
     <View style={styles.container}>
       <GameTopBar onBack={onBack} />
       <Text style={styles.title}>Fill in the Blank</Text>
-      <Text style={styles.description}>Type the missing words in the spaces.</Text>
+      <Text style={styles.description}>Tap the words that fit in the blanks.</Text>
       <Text style={styles.quote}>{display}</Text>
       {current < missing.length && (
-        <View style={styles.inputRow}>
-          <TextInput
-            style={styles.input}
-            value={input}
-            onChangeText={setInput}
-            autoCapitalize="none"
-          />
-          <ThemedButton title="Submit" onPress={handleSubmit} />
+        <View style={styles.options}>
+          {options.map((o, i) => (
+            <TouchableOpacity key={`${o}-${i}`} style={styles.optionButton} onPress={() => handleSelect(o)}>
+              <Text style={styles.optionText}>{o}</Text>
+            </TouchableOpacity>
+          ))}
         </View>
       )}
       {message ? <Text style={styles.message}>{message}</Text> : null}
@@ -90,18 +114,25 @@ const styles = StyleSheet.create({
     marginVertical: 16,
     textAlign: 'center',
   },
-  inputRow: {
+  options: {
     flexDirection: 'row',
-    alignItems: 'center',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
     marginBottom: 16,
   },
-  input: {
-    borderColor: '#ccc',
+  optionButton: {
+    backgroundColor: themeVariables.whiteColor,
     borderWidth: 1,
-    paddingHorizontal: 8,
-    marginRight: 8,
-    height: 40,
-    minWidth: 80,
+    borderColor: themeVariables.primaryColor,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    margin: 4,
+    borderRadius: themeVariables.borderRadiusPill,
+  },
+  optionText: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    fontWeight: 'bold',
   },
   message: {
     fontSize: 18,


### PR DESCRIPTION
## Summary
- refactor FastTypeGame into Tap It Fast timed button game
- convert FillBlankTypingGame, FirstLetterQuizGame, FlashCardRecallGame, LetterScrambleGame, and QuotePracticeScreen to use button options instead of typing

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_685e4186e2c48328a31db38c1150521f