### PR TITLE
Add extra game screens

### DIFF
--- a/games/BuildRecallGame.jsx
+++ b/games/BuildRecallGame.jsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+const shuffle = (arr) => arr.sort(() => Math.random() - 0.5);
+
+// Show a short sequence of words from the quote. After the preview,
+// players tap the words in the same order to reinforce recall.
+const BuildRecallGame = ({ quote, onBack }) => {
+  const words = quote.split(/\s+/).slice(0, 3);
+  const [sequence, setSequence] = useState([]); // order to memorize
+  const [showIndex, setShowIndex] = useState(0); // playback index
+  const [userIndex, setUserIndex] = useState(0); // player progress
+  const [highlight, setHighlight] = useState(null);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    startRound();
+  }, []);
+
+  const startRound = () => {
+    // pick a random order of the words to show
+    const seq = shuffle([0, 1, 2]);
+    setSequence(seq);
+    setShowIndex(0);
+    setUserIndex(0);
+    setMessage('');
+  };
+
+  useEffect(() => {
+    if (showIndex < sequence.length) {
+      const idx = sequence[showIndex];
+      setTimeout(() => {
+        setHighlight(idx);
+        setTimeout(() => {
+          setHighlight(null);
+          setShowIndex((p) => p + 1);
+        }, 400);
+      }, 600);
+    }
+  }, [showIndex, sequence]);
+
+  const handlePress = (idx) => {
+    if (showIndex < sequence.length) return;
+    if (sequence[userIndex] === idx) {
+      const next = userIndex + 1;
+      setUserIndex(next);
+      if (next === sequence.length) {
+        setMessage('Great job!');
+      }
+    } else {
+      setMessage('Try again');
+      startRound();
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Build & Recall</Text>
+      <Text style={styles.description}>Watch the word order then repeat it.</Text>
+      <View style={styles.row}>
+        {words.map((w, i) => (
+          <TouchableOpacity
+            key={i}
+            style={[styles.block, highlight === i && styles.highlight]}
+            onPress={() => handlePress(i)}
+          >
+            <Text style={styles.word}>{w}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: themeVariables.neutralLight,
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    marginTop: 16,
+  },
+  block: {
+    minWidth: 70,
+    paddingVertical: 16,
+    paddingHorizontal: 12,
+    margin: 8,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+    borderRadius: themeVariables.borderRadiusPill,
+    backgroundColor: themeVariables.whiteColor,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  highlight: {
+    backgroundColor: themeVariables.primaryColorLight,
+  },
+  word: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    fontWeight: 'bold',
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default BuildRecallGame;

--- a/games/ColorSwitchGame.jsx
+++ b/games/ColorSwitchGame.jsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+// Show a line of words. After a short delay one word changes colour.
+// The player must tap the word that changed.
+const palette = [
+  themeVariables.primaryColorLight,
+  '#ffd93d',
+  '#6bcb77',
+  '#4d96ff',
+];
+
+const ColorSwitchGame = ({ quote, onBack }) => {
+  const words = quote.split(/\s+/).slice(0, 4);
+  const [colors, setColors] = useState([]);
+  const [changedIndex, setChangedIndex] = useState(0);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    startRound();
+  }, []);
+
+  const startRound = () => {
+    const base = palette.map((c) => c);
+    setColors(base);
+    const idx = Math.floor(Math.random() * base.length);
+    setChangedIndex(idx);
+    setMessage('');
+    setTimeout(() => {
+      const newCols = [...base];
+      const other = (idx + 1) % base.length;
+      newCols[idx] = palette[other];
+      setColors(newCols);
+    }, 2000);
+  };
+
+  const handlePress = (idx) => {
+    if (idx === changedIndex) {
+      setMessage('Great job!');
+    } else {
+      setMessage('Try again');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Color Switch</Text>
+      <Text style={styles.description}>Tap the word that changed colour.</Text>
+      <View style={styles.row}>
+        {words.map((w, i) => (
+          <TouchableOpacity
+            key={i}
+            style={[styles.wordBox, { backgroundColor: colors[i] }]}
+            onPress={() => handlePress(i)}
+          >
+            <Text style={styles.word}>{w}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: themeVariables.neutralLight,
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  wordBox: {
+    minWidth: 60,
+    paddingVertical: 12,
+    paddingHorizontal: 8,
+    margin: 8,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+    borderRadius: themeVariables.borderRadiusPill,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  word: {
+    color: themeVariables.primaryColorDark,
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default ColorSwitchGame;

--- a/games/MemoryMazeGame.jsx
+++ b/games/MemoryMazeGame.jsx
@@ -1,0 +1,173 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+const size = 3;
+const path = ['R', 'D', 'D', 'R'];
+
+// During the preview, highlight the path across a grid of words from the quote.
+// The player then moves along the grid from memory using the arrow buttons.
+const MemoryMazeGame = ({ quote, onBack }) => {
+  const words = quote.split(/\s+/).slice(0, size * size);
+  const [preview, setPreview] = useState(true);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [step, setStep] = useState(0);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setPreview(true);
+    setPos({ x: 0, y: 0 });
+    setStep(0);
+    setMessage('');
+    const timer = setTimeout(() => setPreview(false), 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const move = (dir) => {
+    if (preview || message) return;
+    const expected = path[step];
+    if (dir !== expected) {
+      setMessage('Try again');
+      return;
+    }
+    const next = { ...pos };
+    if (dir === 'R') next.x += 1;
+    if (dir === 'L') next.x -= 1;
+    if (dir === 'U') next.y -= 1;
+    if (dir === 'D') next.y += 1;
+    setPos(next);
+    const newStep = step + 1;
+    if (newStep === path.length) {
+      setMessage('Great job!');
+    } else {
+      setStep(newStep);
+    }
+  };
+
+  const renderCell = (x, y, index) => {
+    let bg = themeVariables.whiteColor;
+    if (preview) {
+      const idx = path.findIndex((d, i) => {
+        let px = 0, py = 0;
+        for (let j = 0; j <= i; j++) {
+          const d2 = path[j];
+          if (d2 === 'R') px += 1;
+          if (d2 === 'L') px -= 1;
+          if (d2 === 'U') py -= 1;
+          if (d2 === 'D') py += 1;
+        }
+        return px === x && py === y;
+      });
+      if (x === 0 && y === 0) bg = '#6bcb77';
+      else if (idx !== -1) bg = '#ffd93d';
+      else if (x === size - 1 && y === size - 1) bg = '#4d96ff';
+    } else {
+      if (pos.x === x && pos.y === y) bg = '#6bcb77';
+      if (x === size - 1 && y === size - 1) bg = '#4d96ff';
+    }
+    const word = words[index] || '';
+    return (
+      <View key={index} style={[styles.cell, { backgroundColor: bg }]}>\
+        <Text style={styles.word}>{word}</Text>
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Memory Maze</Text>
+      <Text style={styles.description}>Navigate to the goal from memory.</Text>
+      <View style={styles.grid}>
+        {Array.from({ length: size }).map((_, y) => (
+          <View key={y} style={styles.row}>
+            {Array.from({ length: size }).map((_, x) =>
+              renderCell(x, y, `${x}-${y}`),
+            )}
+          </View>
+        ))}
+      </View>
+      <View style={styles.controls}>
+        <View style={styles.controlRow}>
+          <TouchableOpacity onPress={() => move('U')} style={styles.controlBtn}>
+            <Text>U</Text>
+          </TouchableOpacity>
+        </View>
+        <View style={styles.controlRow}>
+          <TouchableOpacity onPress={() => move('L')} style={styles.controlBtn}>
+            <Text>L</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => move('D')} style={styles.controlBtn}>
+            <Text>D</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => move('R')} style={styles.controlBtn}>
+            <Text>R</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: themeVariables.neutralLight,
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  grid: {
+    marginVertical: 16,
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  cell: {
+    width: 60,
+    height: 60,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 2,
+  },
+  word: {
+    fontSize: 12,
+    textAlign: 'center',
+  },
+  controls: {
+    marginVertical: 8,
+  },
+  controlRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  controlBtn: {
+    backgroundColor: themeVariables.whiteColor,
+    padding: 8,
+    margin: 4,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+    borderRadius: themeVariables.borderRadiusPill,
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default MemoryMazeGame;

--- a/games/RhythmRepeatGame.jsx
+++ b/games/RhythmRepeatGame.jsx
@@ -1,0 +1,125 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+// Use the first three words of the quote as the rhythm elements.
+const shuffle = (arr) => arr.sort(() => Math.random() - 0.5);
+
+const RhythmRepeatGame = ({ quote, onBack }) => {
+  const words = quote.split(/\s+/).slice(0, 3);
+  const [sequence, setSequence] = useState([]); // playback order
+  const [playIndex, setPlayIndex] = useState(0);
+  const [userIndex, setUserIndex] = useState(0);
+  const [highlight, setHighlight] = useState(null);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    startRound();
+  }, []);
+
+  const startRound = () => {
+    // shuffle order of the words for playback
+    const seq = shuffle([0, 1, 2]);
+    setSequence(seq);
+    setPlayIndex(0);
+    setUserIndex(0);
+    setMessage('');
+  };
+
+  useEffect(() => {
+    if (playIndex < sequence.length) {
+      const idx = sequence[playIndex];
+      setTimeout(() => {
+        setHighlight(idx);
+        setTimeout(() => {
+          setHighlight(null);
+          setPlayIndex((p) => p + 1);
+        }, 400);
+      }, 600);
+    }
+  }, [playIndex, sequence]);
+
+  const handlePress = (idx) => {
+    if (playIndex < sequence.length) return; // wait for playback
+    if (sequence[userIndex] === idx) {
+      const next = userIndex + 1;
+      setUserIndex(next);
+      if (next === sequence.length) {
+        setMessage('Great job!');
+      }
+    } else {
+      setMessage('Try again');
+      startRound();
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Rhythm Repeat</Text>
+      <Text style={styles.description}>Watch the word rhythm then repeat it.</Text>
+      <View style={styles.row}>
+        {words.map((w, i) => (
+          <TouchableOpacity
+            key={i}
+            style={[styles.beat, highlight === i && styles.highlight]}
+            onPress={() => handlePress(i)}
+          >
+            <Text style={styles.word}>{w}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: themeVariables.neutralLight,
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    marginTop: 16,
+  },
+  beat: {
+    width: 70,
+    height: 70,
+    margin: 8,
+    borderRadius: 35,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+  },
+  highlight: {
+    backgroundColor: themeVariables.primaryColorLight,
+  },
+  word: {
+    color: themeVariables.primaryColorDark,
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default RhythmRepeatGame;

--- a/games/SceneChangeGame.jsx
+++ b/games/SceneChangeGame.jsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+const palette = [
+  themeVariables.primaryColorLight,
+  '#ffd93d',
+  '#6bcb77',
+  '#4d96ff',
+];
+
+// Display a line of words; one word changes colour.
+const SceneChangeGame = ({ quote, onBack }) => {
+  const words = quote.split(/\s+/).slice(0, 4);
+  const [colors, setColors] = useState([]);
+  const [changed, setChanged] = useState(0);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    startRound();
+  }, []);
+
+  const startRound = () => {
+    const base = palette.slice(0, words.length);
+    setColors(base);
+    const idx = Math.floor(Math.random() * base.length);
+    setChanged(idx);
+    setMessage('');
+    setTimeout(() => {
+      const newCols = [...base];
+      const other = (idx + 2) % palette.length;
+      newCols[idx] = palette[other];
+      setColors(newCols);
+    }, 2000);
+  };
+
+  const handlePress = (i) => {
+    if (i === changed) {
+      setMessage('Great job!');
+    } else {
+      setMessage('Try again');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Which Scene Changed?</Text>
+      <Text style={styles.description}>Tap the word that changed colour.</Text>
+      <View style={styles.grid}>
+        {words.map((w, i) => (
+          <TouchableOpacity
+            key={i}
+            style={[styles.wordBox, { backgroundColor: colors[i] }]}
+            onPress={() => handlePress(i)}
+          >
+            <Text style={styles.word}>{w}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: themeVariables.neutralLight,
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    width: 140,
+  },
+  wordBox: {
+    minWidth: 60,
+    paddingVertical: 12,
+    paddingHorizontal: 8,
+    margin: 8,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+    borderRadius: themeVariables.borderRadiusPill,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  word: {
+    color: themeVariables.primaryColorDark,
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default SceneChangeGame;

--- a/games/ShapeBuilderGame.jsx
+++ b/games/ShapeBuilderGame.jsx
@@ -1,0 +1,152 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+// Drag pieces (words) into their correct positions to rebuild part of the quote.
+const colors = [
+  themeVariables.primaryColorLight,
+  '#ffd93d',
+  '#6bcb77',
+  '#4d96ff',
+];
+
+const shuffle = (arr) => arr.sort(() => Math.random() - 0.5);
+
+const ShapeBuilderGame = ({ quote, onBack }) => {
+  const words = quote.split(/\s+/).slice(0, 4);
+  const [showPreview, setShowPreview] = useState(true);
+  const [grid, setGrid] = useState(Array(4).fill(null)); // placed indices
+  const [pieces, setPieces] = useState([]); // shuffled piece indices
+  const [selected, setSelected] = useState(null);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setShowPreview(true);
+    setGrid(Array(4).fill(null));
+    setPieces(shuffle([0, 1, 2, 3])); // indices referring to words
+    setSelected(null);
+    setMessage('');
+    const timer = setTimeout(() => setShowPreview(false), 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const handlePiecePress = (p) => {
+    setSelected(p);
+    setMessage('');
+  };
+
+  const handleCellPress = (idx) => {
+    if (showPreview || grid[idx] !== null || selected === null) return;
+    if (idx === selected) {
+      const next = [...grid];
+      next[idx] = words[idx];
+      setGrid(next);
+      setPieces((prev) => prev.filter((n) => n !== selected));
+      setSelected(null);
+      if (next.every((c) => c !== null)) {
+        setMessage('Great job!');
+      }
+    } else {
+      setMessage('Try again');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Shape Builder</Text>
+      <Text style={styles.description}>Place each word in the right spot.</Text>
+      <View style={styles.grid}>
+        {grid.map((c, i) => (
+          <TouchableOpacity
+            key={i}
+            style={[
+              styles.cell,
+              { backgroundColor: showPreview ? colors[i] : themeVariables.whiteColor },
+            ]}
+            onPress={() => handleCellPress(i)}
+          >
+            {(showPreview || c) && <Text style={styles.word}>{words[i]}</Text>}
+          </TouchableOpacity>
+        ))}
+      </View>
+      <View style={styles.pieces}>
+        {pieces.map((p) => (
+          <TouchableOpacity
+            key={p}
+            style={[
+              styles.piece,
+              { backgroundColor: colors[p], opacity: selected === p ? 0.5 : 1 },
+            ]}
+            onPress={() => handlePiecePress(p)}
+          >
+            <Text style={styles.word}>{words[p]}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: themeVariables.neutralLight,
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    width: 160,
+    height: 160,
+  },
+  cell: {
+    width: 80,
+    height: 80,
+    margin: 2,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pieces: {
+    flexDirection: 'row',
+    marginTop: 16,
+  },
+  piece: {
+    width: 50,
+    height: 50,
+    margin: 4,
+    borderRadius: themeVariables.borderRadiusSharp,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  word: {
+    fontSize: 16,
+    color: themeVariables.primaryColorDark,
+    textAlign: 'center',
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default ShapeBuilderGame;

--- a/games/SilhouetteSearchGame.jsx
+++ b/games/SilhouetteSearchGame.jsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+// Show two target words in silhouette, then let the player select them from a list.
+
+const SilhouetteSearchGame = ({ quote, onBack }) => {
+  const words = quote.split(/\s+/).slice(0, 4);
+  const [targets, setTargets] = useState([]);
+  const [found, setFound] = useState([]);
+  const [showPreview, setShowPreview] = useState(true);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    // choose two target words
+    const indices = [0, 1];
+    setTargets(indices.map((i) => ({ word: words[i], id: i })));
+    setFound([]);
+    setShowPreview(true);
+    setMessage('');
+    const timer = setTimeout(() => setShowPreview(false), 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const handlePress = (id) => {
+    if (showPreview) return;
+    if (targets.find((t) => t.id === id) && !found.includes(id)) {
+      const newFound = [...found, id];
+      setFound(newFound);
+      if (newFound.length === targets.length) setMessage('Great job!');
+    } else {
+      setMessage('Try again');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Silhouette Search</Text>
+      <Text style={styles.description}>Tap the words that match the targets.</Text>
+      <View style={styles.row}>
+        {targets.map((t) => (
+          <View key={t.id} style={styles.targetBox}>
+            <Text style={styles.targetWord}>{t.word}</Text>
+          </View>
+        ))}
+      </View>
+      {!showPreview && (
+        <View style={styles.row}>
+          {words.map((w, i) => (
+            <TouchableOpacity
+              key={i}
+              style={styles.optionBox}
+              onPress={() => handlePress(i)}
+            >
+              <Text style={styles.optionWord}>{w}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: themeVariables.neutralLight,
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    marginVertical: 8,
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  targetBox: {
+    padding: 12,
+    margin: 8,
+    backgroundColor: '#000',
+  },
+  targetWord: {
+    color: '#fff',
+    fontSize: 18,
+  },
+  optionBox: {
+    padding: 12,
+    margin: 8,
+    backgroundColor: themeVariables.whiteColor,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+    borderRadius: themeVariables.borderRadiusPill,
+  },
+  optionWord: {
+    color: themeVariables.primaryColorDark,
+    fontSize: 18,
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default SilhouetteSearchGame;

--- a/games/WordSwapGame.jsx
+++ b/games/WordSwapGame.jsx
@@ -1,0 +1,90 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+const WordSwapGame = ({ quote, onBack }) => {
+  const words = quote.split(/\s+/).slice(0, 8);
+  const [showOriginal, setShowOriginal] = useState(true);
+  const [changedIndex, setChangedIndex] = useState(0);
+  const [modified, setModified] = useState([]);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const idx = Math.floor(Math.random() * words.length);
+    setChangedIndex(idx);
+    const copy = [...words];
+    copy[idx] = '____';
+    setModified(copy);
+    setShowOriginal(true);
+    setMessage('');
+    const timer = setTimeout(() => {
+      const mod = [...words];
+      mod[idx] = '???';
+      setModified(mod);
+      setShowOriginal(false);
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [quote]);
+
+  const handlePress = (i) => {
+    if (showOriginal) return;
+    if (i === changedIndex) {
+      setMessage('Great job!');
+    } else {
+      setMessage('Try again');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Word Swap</Text>
+      <Text style={styles.description}>Tap the word that changed.</Text>
+      <View style={styles.sentence}>
+        {modified.map((w, i) => (
+          <TouchableOpacity key={i} onPress={() => handlePress(i)}>
+            <Text style={styles.word}>{w} </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: themeVariables.neutralLight,
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  sentence: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginVertical: 16,
+  },
+  word: {
+    fontSize: 20,
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default WordSwapGame;

--- a/games/gameRoutes.js
+++ b/games/gameRoutes.js
@@ -10,6 +10,14 @@ import LetterScrambleGame from './LetterScrambleGame';
 import FastTypeGame from './FastTypeGame';
 import HangmanGame from './HangmanGame';
 import FillBlankTypingGame from './FillBlankTypingGame';
+import ShapeBuilderGame from './ShapeBuilderGame';
+import ColorSwitchGame from './ColorSwitchGame';
+import RhythmRepeatGame from './RhythmRepeatGame';
+import SilhouetteSearchGame from './SilhouetteSearchGame';
+import MemoryMazeGame from './MemoryMazeGame';
+import SceneChangeGame from './SceneChangeGame';
+import WordSwapGame from './WordSwapGame';
+import BuildRecallGame from './BuildRecallGame';
 
 export const gameScreens = {
   practice: QuotePracticeScreen,
@@ -24,4 +32,12 @@ export const gameScreens = {
   fastTypeGame: FastTypeGame,
   hangmanGame: HangmanGame,
   fillBlankGame: FillBlankTypingGame,
+  shapeBuilderGame: ShapeBuilderGame,
+  colorSwitchGame: ColorSwitchGame,
+  rhythmRepeatGame: RhythmRepeatGame,
+  silhouetteSearchGame: SilhouetteSearchGame,
+  memoryMazeGame: MemoryMazeGame,
+  sceneChangeGame: SceneChangeGame,
+  wordSwapGame: WordSwapGame,
+  buildRecallGame: BuildRecallGame,
 };

--- a/games/index.js
+++ b/games/index.js
@@ -15,6 +15,14 @@ export const gameIds = [
   'fastTypeGame',
   'hangmanGame',
   'fillBlankGame',
+  'shapeBuilderGame',
+  'colorSwitchGame',
+  'rhythmRepeatGame',
+  'silhouetteSearchGame',
+  'memoryMazeGame',
+  'sceneChangeGame',
+  'wordSwapGame',
+  'buildRecallGame',
 ];
 
 /**


### PR DESCRIPTION
## Summary
- add several new mini-games inspired by previous ideas
- register the new games in `gameRoutes` and `games/index`
- refactor the new games so they incorporate the quote text

## Testing
- `npm test` *(fails: Cannot find module 'react-dom')*
- `npm run lint` *(fails: 11 errors, 31 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685e8c723ecc83288656422f5fd8b2b6