### PR TITLE
Add difficulty selector

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { UserProvider } from './contexts/UserContext';
+import { DifficultyProvider } from './contexts/DifficultyContext';
 import MainApp from './components/MainApp';
 
 const App = () => (
   <UserProvider>
-    <MainApp />
+    <DifficultyProvider>
+      <MainApp />
+    </DifficultyProvider>
   </UserProvider>
 );
 

--- a/components/DifficultyFAB.jsx
+++ b/components/DifficultyFAB.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { faSliders } from '@fortawesome/free-solid-svg-icons';
+import { useDifficulty } from '../contexts/DifficultyContext';
+import theme from '../styles/theme';
+
+const DifficultyFAB = () => {
+  const { level, setLevel } = useDifficulty();
+  const [open, setOpen] = useState(false);
+
+  const LevelButton = ({ value }) => (
+    <TouchableOpacity
+      style={[styles.levelButton, level === value && styles.selected]}
+      onPress={() => {
+        setLevel(value);
+        setOpen(false);
+      }}
+    >
+      <Text style={styles.levelText}>{value}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container} pointerEvents="box-none">
+      {open && (
+        <View style={styles.levelContainer} pointerEvents="box-none">
+          {[1, 2, 3].map((val) => (
+            <LevelButton key={val} value={val} />
+          ))}
+        </View>
+      )}
+      <TouchableOpacity style={styles.fab} onPress={() => setOpen(!open)}>
+        <FontAwesomeIcon icon={faSliders} size={24} color={theme.whiteColor} />
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 24,
+    right: 24,
+    alignItems: 'center',
+  },
+  fab: {
+    backgroundColor: theme.primaryColor,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 4,
+  },
+  levelContainer: {
+    marginBottom: 8,
+    alignItems: 'center',
+  },
+  levelButton: {
+    backgroundColor: theme.whiteColor,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    marginBottom: 4,
+    borderRadius: theme.borderRadiusPill,
+    borderWidth: 1,
+    borderColor: theme.primaryColor,
+  },
+  levelText: {
+    fontSize: 16,
+    color: theme.primaryColor,
+    fontWeight: 'bold',
+  },
+  selected: {
+    backgroundColor: theme.primaryLightColor,
+  },
+});
+
+export default DifficultyFAB;

--- a/components/MainApp.jsx
+++ b/components/MainApp.jsx
@@ -45,6 +45,7 @@ import {
 
 // Notification banner shown when an achievement is earned, auto-dismisses after a delay
 import NotificationBanner from './NotificationBanner';
+import DifficultyFAB from './DifficultyFAB';
 
  const MainApp = () => {
   // access user context (user, family, children, classes)
@@ -437,7 +438,12 @@ import NotificationBanner from './NotificationBanner';
     if (gameScreens[nav.screen]) {
       const GameComponent = gameScreens[nav.screen];
       const backHandler = nav.fromGames ? goGames : goBackToLesson;
-      return <GameComponent quote={nav.quote} onBack={backHandler} />;
+      return (
+        <View style={{ flex: 1 }}>
+          <GameComponent quote={nav.quote} onBack={backHandler} />
+          <DifficultyFAB />
+        </View>
+      );
     }
     if (nav.screen === 'grade2Set') {
       const backHandler = nav.setNumber === 2 ? goHome : goBackToGrade2;

--- a/contexts/DifficultyContext.jsx
+++ b/contexts/DifficultyContext.jsx
@@ -1,0 +1,14 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const DifficultyContext = createContext();
+
+export const DifficultyProvider = ({ children }) => {
+  const [level, setLevel] = useState(1); // default easy
+  return (
+    <DifficultyContext.Provider value={{ level, setLevel }}>
+      {children}
+    </DifficultyContext.Provider>
+  );
+};
+
+export const useDifficulty = () => useContext(DifficultyContext);

--- a/games/ColorSwitchGame.jsx
+++ b/games/ColorSwitchGame.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import GameTopBar from '../components/GameTopBar';
+import { useDifficulty } from '../contexts/DifficultyContext';
 import themeVariables from '../styles/theme';
 
 // Show a line of words. After a short delay one word changes colour.
@@ -13,7 +14,9 @@ const palette = [
 ];
 
 const ColorSwitchGame = ({ quote, onBack }) => {
+  const { level } = useDifficulty();
   const text = typeof quote === 'string' ? quote : quote?.text || '';
+  const delay = level === 1 ? 2000 : level === 2 ? 1500 : 1000;
   const words = text.split(/\s+/).slice(0, 4);
   const [colors, setColors] = useState([]);
   const [changedIndex, setChangedIndex] = useState(0);
@@ -21,7 +24,7 @@ const ColorSwitchGame = ({ quote, onBack }) => {
 
   useEffect(() => {
     startRound();
-  }, []);
+  }, [level]);
 
   const startRound = () => {
     const base = palette.map((c) => c);
@@ -34,7 +37,7 @@ const ColorSwitchGame = ({ quote, onBack }) => {
       const other = (idx + 1) % base.length;
       newCols[idx] = palette[other];
       setColors(newCols);
-    }, 2000);
+    }, delay);
   };
 
   const handlePress = (idx) => {

--- a/games/TapScrambledGame.jsx
+++ b/games/TapScrambledGame.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import ThemedButton from '../components/ThemedButton';
 import GameTopBar from '../components/GameTopBar';
+import { useDifficulty } from '../contexts/DifficultyContext';
 import themeVariables from '../styles/theme';
 
 const shuffle = (arr) => {
@@ -14,6 +15,7 @@ const shuffle = (arr) => {
 };
 
 const TapScrambledGame = ({ quote, onBack }) => {
+  const { level } = useDifficulty();
   const text = typeof quote === 'string' ? quote : quote?.text || '';
   const [words, setWords] = useState([]);
   const [scrambled, setScrambled] = useState([]);
@@ -21,12 +23,13 @@ const TapScrambledGame = ({ quote, onBack }) => {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    const w = text.split(/\s+/).slice(0, 8);
+    const limit = level === 1 ? 8 : level === 2 ? 12 : 16;
+    const w = text.split(/\s+/).slice(0, limit);
     setWords(w);
     setScrambled(shuffle(w));
     setIndex(0);
     setMessage('');
-  }, [quote]);
+  }, [quote, level]);
 
   const handlePress = (word, idx) => {
     if (word === words[index]) {


### PR DESCRIPTION
## Summary
- create DifficultyContext to store global difficulty level
- add DifficultyFAB for selecting difficulty
- show DifficultyFAB on game screens
- adjust TapScrambled and ColorSwitch games based on difficulty
- wrap app with DifficultyProvider

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find module 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6867b99208a48328b499215281382103