### PR TITLE
Switch to Ionicons

### DIFF
--- a/components/Badge.jsx
+++ b/components/Badge.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Avatar from '@flipxyz/react-native-boring-avatars';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faStar } from '@fortawesome/free-solid-svg-icons';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import themeVariables from '../styles/theme';
 
 const Badge = ({ name, score, isTeacher }) => {
@@ -15,7 +14,7 @@ const Badge = ({ name, score, isTeacher }) => {
         </Text>
         {!isTeacher && (
           <View style={styles.scoreContainer}>
-            <FontAwesomeIcon icon={faStar} size={16} color={themeVariables.primaryColor} />
+          <Ionicons name="star" size={16} color={themeVariables.primaryColor} />
             <Text style={styles.scoreText}>{score}</Text>
           </View>
         )}

--- a/components/DifficultyFAB.jsx
+++ b/components/DifficultyFAB.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faSliders } from '@fortawesome/free-solid-svg-icons';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import { useDifficulty } from '../contexts/DifficultyContext';
 import theme from '../styles/theme';
 
@@ -31,7 +30,7 @@ const DifficultyFAB = () => {
         </View>
       )}
       <TouchableOpacity style={styles.fab} onPress={() => setOpen(!open)}>
-        <FontAwesomeIcon icon={faSliders} size={24} color={theme.whiteColor} />
+        <Ionicons name="options-outline" size={24} color={theme.whiteColor} />
       </TouchableOpacity>
     </View>
   );

--- a/components/GameTile.jsx
+++ b/components/GameTile.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import theme from '../styles/theme';
 
 const GameTile = ({ title, icon, onPress }) => (
   <TouchableOpacity style={styles.tile} onPress={onPress}>
     <View style={styles.iconContainer}>
-      <FontAwesomeIcon icon={icon} size={28} color={theme.primaryColor} />
+      <Ionicons name={icon} size={28} color={theme.primaryColor} />
     </View>
     <Text style={styles.tileText}>{title}</Text>
   </TouchableOpacity>

--- a/components/GameTopBar.jsx
+++ b/components/GameTopBar.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import themeVariables from '../styles/theme';
 
 const GameTopBar = ({ onBack }) => (
   <View style={styles.container}>
     <TouchableOpacity onPress={onBack} style={styles.iconButton}>
-      <FontAwesomeIcon
-        icon={faChevronLeft}
+      <Ionicons
+        name="chevron-back"
         size={24}
         color={themeVariables.primaryColor}
       />

--- a/components/MainApp.jsx
+++ b/components/MainApp.jsx
@@ -4,9 +4,7 @@ import Avatar from '@flipxyz/react-native-boring-avatars';
 import ThemedButton from './ThemedButton';
 import GradesScreen from '../screens/GradesScreen';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-// Use FontAwesome via @fortawesome/react-native-fontawesome
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faTrash, faHome, faBook, faTrophy, faCog, faGamepad, faChalkboardTeacher } from '@fortawesome/free-solid-svg-icons';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 // import Grade1Screen from './screens/Grade1Screen';
 import Grade2Screen from '../screens/Grade2Screen';
 import Grade2SetScreen from '../screens/Grade2SetScreen';
@@ -664,27 +662,27 @@ import DifficultyFAB from './DifficultyFAB';
       </View>
       <View style={styles.bottomNav}>
         <TouchableOpacity style={styles.navItem} onPress={goHome}>
-          <FontAwesomeIcon icon={faHome} size={24} color="#333" />
+          <Ionicons name="home" size={24} color="#333" />
           <Text style={styles.navText}>Home</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.navItem} onPress={goGrades}>
-          <FontAwesomeIcon icon={faBook} size={24} color="#333" />
+          <Ionicons name="book" size={24} color="#333" />
           <Text style={styles.navText}>Grade</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.navItem} onPress={goClass}>
-          <FontAwesomeIcon icon={faChalkboardTeacher} size={24} color="#333" />
+          <Ionicons name="school" size={24} color="#333" />
           <Text style={styles.navText}>Classes</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.navItem} onPress={goGames}>
-          <FontAwesomeIcon icon={faGamepad} size={24} color="#333" />
+          <Ionicons name="game-controller" size={24} color="#333" />
           <Text style={styles.navText}>Game</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.navItem} onPress={goAchievements}>
-          <FontAwesomeIcon icon={faTrophy} size={24} color="#333" />
+          <Ionicons name="trophy" size={24} color="#333" />
           <Text style={styles.navText}>Badges</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.navItem} onPress={goSettings}>
-          <FontAwesomeIcon icon={faCog} size={24} color="#333" />
+          <Ionicons name="settings" size={24} color="#333" />
           <Text style={styles.navText}>Settings</Text>
         </TouchableOpacity>
       </View>

--- a/screens/AchievementsScreen.jsx
+++ b/screens/AchievementsScreen.jsx
@@ -1,19 +1,17 @@
 import React, { useRef, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
-// Use FontAwesome via @fortawesome/react-native-fontawesome
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faCalendarCheck, faTrophy, faStar } from '@fortawesome/free-solid-svg-icons';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import themeVariables from '../styles/theme';
 
-// Map icon name strings to FontAwesome icons
+// Map icon name strings to Ionicons names
 const iconMap = {
-  'calendar-check-o': faCalendarCheck,
-  'trophy': faTrophy,
+  'calendar-check-o': 'calendar',
+  'trophy': 'trophy',
 };
 const AchievementItem = ({ icon, title, description, points, earned }) => (
   <View style={styles.item}>
-    <FontAwesomeIcon
-      icon={iconMap[icon]}
+    <Ionicons
+      name={iconMap[icon]}
       size={32}
       color={earned ? themeVariables.secondaryColor : '#ccc'}
     />
@@ -23,8 +21,8 @@ const AchievementItem = ({ icon, title, description, points, earned }) => (
     </View>
     <View style={styles.pointsContainer}>
       <Text style={styles.pointsText}>{points}</Text>
-      <FontAwesomeIcon
-        icon={faStar}
+      <Ionicons
+        name="star"
         size={24}
         color={earned ? themeVariables.secondaryColor : '#ccc'}
       />

--- a/screens/GamesListScreen.jsx
+++ b/screens/GamesListScreen.jsx
@@ -1,29 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import GameTile from '../components/GameTile';
-import {
-  faBookOpen,
-  faHandPointer,
-  faRandom,
-  faArrowRight,
-  faBrain,
-  faBolt,
-  faEye,
-  faFont,
-  faSortAlphaDown,
-  faKeyboard,
-  faUserNinja,
-  faPen,
-  faGamepad,
-  faPuzzlePiece,
-  faPalette,
-  faMusic,
-  faBinoculars,
-  faMap,
-  faImages,
-  faExchangeAlt,
-  faTools,
-} from '@fortawesome/free-solid-svg-icons';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import { gameIds } from '../games';
 import themeVariables from '../styles/theme';
 
@@ -43,26 +21,26 @@ const titles = {
 };
 
 const iconMap = {
-  practice: faBookOpen,
-  tapGame: faHandPointer,
-  scrambleGame: faRandom,
-  nextWordGame: faArrowRight,
-  memoryGame: faBrain,
-  flashGame: faBolt,
-  revealGame: faEye,
-  firstLetterGame: faFont,
-  letterScrambleGame: faSortAlphaDown,
-  fastTypeGame: faKeyboard,
-  hangmanGame: faUserNinja,
-  fillBlankGame: faPen,
-  shapeBuilderGame: faPuzzlePiece,
-  colorSwitchGame: faPalette,
-  rhythmRepeatGame: faMusic,
-  silhouetteSearchGame: faBinoculars,
-  memoryMazeGame: faMap,
-  sceneChangeGame: faImages,
-  wordSwapGame: faExchangeAlt,
-  buildRecallGame: faTools,
+  practice: 'book-outline',
+  tapGame: 'hand-left',
+  scrambleGame: 'shuffle',
+  nextWordGame: 'arrow-forward',
+  memoryGame: 'analytics',
+  flashGame: 'flash',
+  revealGame: 'eye',
+  firstLetterGame: 'text',
+  letterScrambleGame: 'reorder-four',
+  fastTypeGame: 'keypad',
+  hangmanGame: 'body',
+  fillBlankGame: 'pencil',
+  shapeBuilderGame: 'extension-puzzle',
+  colorSwitchGame: 'color-palette',
+  rhythmRepeatGame: 'musical-notes',
+  silhouetteSearchGame: 'search',
+  memoryMazeGame: 'map',
+  sceneChangeGame: 'images',
+  wordSwapGame: 'swap-horizontal',
+  buildRecallGame: 'build',
 };
 
 const GamesListScreen = ({ onSelect }) => (
@@ -73,7 +51,7 @@ const GamesListScreen = ({ onSelect }) => (
         <GameTile
           key={id}
           title={titles[id] || id}
-          icon={iconMap[id] || faGamepad}
+          icon={iconMap[id] || 'game-controller'}
           onPress={() => onSelect(id)}
         />
       ))}

--- a/screens/HomeScreen.jsx
+++ b/screens/HomeScreen.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faStar, faCamera } from '@fortawesome/free-solid-svg-icons';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import Avatar from '@flipxyz/react-native-boring-avatars';
 import { Button } from 'liquid-spirit-styleguide';
 import themeVariables from '../styles/theme';
@@ -27,7 +26,7 @@ const HomeScreen = ({ profile, achievements, onDailyChallenge, onTestMemory, onS
               <Avatar size={60} name={profile.name} variant="beam" />
             )}
             <View style={styles.avatarOverlay}>
-              <FontAwesomeIcon icon={faCamera} size={14} color={themeVariables.blackColor} />
+              <Ionicons name="camera" size={14} color={themeVariables.blackColor} />
             </View>
           </TouchableOpacity>
           <TouchableOpacity style={styles.profileTextContainer} onPress={onProfilePress}>
@@ -37,7 +36,7 @@ const HomeScreen = ({ profile, achievements, onDailyChallenge, onTestMemory, onS
           </TouchableOpacity>
         </View>
         <View style={styles.pointsContainer}>
-          <FontAwesomeIcon icon={faStar} size={20} color="#f1c40f" />
+          <Ionicons name="star" size={20} color="#f1c40f" />
           <Text style={styles.pointsText}>{totalPoints}</Text>
         </View>
       </View>

--- a/screens/SettingsScreen.jsx
+++ b/screens/SettingsScreen.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ScrollView, View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import themeVariables from '../styles/theme';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import { grade1Lessons } from '../data/grade1';
 import { quoteMap } from '../data/grade2';
 import { Button } from 'liquid-spirit-styleguide';
@@ -66,7 +65,7 @@ const SettingsScreen = ({ profile, currentProgress, overrideProgress, onSaveOver
         ))}
         <Text style={styles.sectionTitle}>Account</Text>
         <TouchableOpacity style={[styles.listItem, styles.accountItem]} onPress={onReset}>
-          <FontAwesomeIcon icon={faTrash} size={16} color={themeVariables.redColor} style={styles.accountIcon} />
+          <Ionicons name="trash" size={16} color={themeVariables.redColor} style={styles.accountIcon} />
           <Text style={[styles.listItemText, styles.accountText]}>Wipe User Details</Text>
         </TouchableOpacity>
       </ScrollView>
@@ -108,7 +107,7 @@ const SettingsScreen = ({ profile, currentProgress, overrideProgress, onSaveOver
         ))}
         <Text style={styles.sectionTitle}>Account</Text>
         <TouchableOpacity style={[styles.listItem, styles.accountItem]} onPress={onReset}>
-          <FontAwesomeIcon icon={faTrash} size={16} color={themeVariables.redColor} style={styles.accountIcon} />
+          <Ionicons name="trash" size={16} color={themeVariables.redColor} style={styles.accountIcon} />
           <Text style={[styles.listItemText, styles.accountText]}>Wipe User Details</Text>
         </TouchableOpacity>
       </ScrollView>


### PR DESCRIPTION
## Summary
- use Ionicons instead of FontAwesome icons
- update navigation and game icons

## Testing
- `npm test` *(fails: Cannot find module 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_686d06c4dfb48328af116ad1ef2aa774