### PR TITLE
Add navigation tests for WelcomeScreen

### DIFF
--- a/__tests__/authFlow.test.js
+++ b/__tests__/authFlow.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import WelcomeScreen from '../screens/WelcomeScreen.jsx';
+
+describe('WelcomeScreen sign in navigation', () => {
+  it('navigates to GuestLogin from Continue as Guest', () => {
+    const navigate = jest.fn();
+    let instance;
+    ReactTestRenderer.act(() => {
+      instance = ReactTestRenderer.create(<WelcomeScreen navigation={{ navigate }} />);
+    });
+    ReactTestRenderer.act(() => {
+      instance.root.findByProps({ label: 'Continue as Guest' }).props.onPress();
+    });
+    expect(navigate).toHaveBeenCalledWith('GuestLogin');
+  });
+
+  it('navigates to NuriRegister from Register button', () => {
+    const navigate = jest.fn();
+    let instance;
+    ReactTestRenderer.act(() => {
+      instance = ReactTestRenderer.create(<WelcomeScreen navigation={{ navigate }} />);
+    });
+    ReactTestRenderer.act(() => {
+      instance.root.findByProps({ label: 'Register' }).props.onPress();
+    });
+    expect(navigate).toHaveBeenCalledWith('NuriRegister');
+  });
+
+  it('navigates to NuriLogin from Login button', () => {
+    const navigate = jest.fn();
+    let instance;
+    ReactTestRenderer.act(() => {
+      instance = ReactTestRenderer.create(<WelcomeScreen navigation={{ navigate }} />);
+    });
+    ReactTestRenderer.act(() => {
+      instance.root.findByProps({ label: 'Login' }).props.onPress();
+    });
+    expect(navigate).toHaveBeenCalledWith('NuriLogin');
+  });
+
+  it('navigates to LSLogin from Liquid Spirit button', () => {
+    const navigate = jest.fn();
+    let instance;
+    ReactTestRenderer.act(() => {
+      instance = ReactTestRenderer.create(<WelcomeScreen navigation={{ navigate }} />);
+    });
+    ReactTestRenderer.act(() => {
+      instance.root.findByProps({ label: 'Liquid Spirit' }).props.onPress();
+    });
+    expect(navigate).toHaveBeenCalledWith('LSLogin');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,9 +6,10 @@ module.exports = {
     ...preset.transform,
     '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
   },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   transformIgnorePatterns: [
     // Transform these modules by Babel
     // Transform these external modules by Babel
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|react-native-vector-icons|@fortawesome/react-native-fontawesome|react-native-image-picker|@flipxyz/react-native-boring-avatars|react-native-tab-view)/)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@react-navigation.*|react-native-tts|react-native-linear-gradient|react-native-vector-icons|@fortawesome/react-native-fontawesome|react-native-image-picker|@flipxyz/react-native-boring-avatars|react-native-tab-view)/)',
   ],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,28 @@
+jest.mock('liquid-spirit-styleguide', () => {
+  const React = require('react');
+  const MockButton = ({ label, onPress }) => React.createElement('Button', { label, onPress });
+  return { Button: MockButton };
+});
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+  return {
+    NavigationContainer: ({ children }) => React.createElement('NavigationContainer', null, children),
+  };
+});
+jest.mock('@react-navigation/stack', () => {
+  return {
+    createStackNavigator: jest.fn(() => ({
+      Navigator: ({ children }) => children,
+      Screen: ({ children }) => children,
+    })),
+  };
+});
+jest.mock('react-native-gesture-handler', () => ({}));
+jest.mock('react-native-linear-gradient', () => 'LinearGradient');
+
+jest.mock('react-native-tts', () => ({
+  addEventListener: jest.fn(),
+  getInitStatus: jest.fn(() => Promise.resolve()),
+  speak: jest.fn(),
+  stop: jest.fn(),
+}));


### PR DESCRIPTION
## Summary
- add a Jest setup file to mock native modules
- configure Jest to use the setup and transform more packages
- add tests covering all sign-in options on WelcomeScreen

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6874b14207e48328a83f8c55ab9c317b