### PR TITLE
Add Bubble Pop Order mini-game

### DIFF
--- a/components/MainApp.jsx
+++ b/components/MainApp.jsx
@@ -149,7 +149,7 @@ const MainApp = () => {
         </NavigationContainer>
       );
     }
-    if (['practice', 'tapGame', 'scrambleGame', 'nextWordGame', 'memoryGame', 'flashGame', 'revealGame', 'firstLetterGame', 'letterScrambleGame', 'fastTypeGame', 'hangmanGame', 'fillBlankGame', 'shapeBuilderGame', 'colorSwitchGame', 'rhythmRepeatGame', 'silhouetteSearchGame', 'memoryMazeGame', 'sceneChangeGame', 'wordSwapGame', 'buildRecallGame'].includes(nav.screen)) {
+    if (['practice', 'tapGame', 'scrambleGame', 'nextWordGame', 'memoryGame', 'flashGame', 'revealGame', 'firstLetterGame', 'letterScrambleGame', 'fastTypeGame', 'hangmanGame', 'fillBlankGame', 'shapeBuilderGame', 'colorSwitchGame', 'rhythmRepeatGame', 'silhouetteSearchGame', 'memoryMazeGame', 'sceneChangeGame', 'wordSwapGame', 'buildRecallGame', 'bubblePopOrderGame'].includes(nav.screen)) {
       const backHandler = nav.fromGames ? goHome : goBackToLesson;
       return <GameRenderer screen={nav.screen} quote={nav.quote} onBack={backHandler} level={level} awardAchievement={awardAchievement} />;
     }

--- a/games/BubblePopOrderGame.jsx
+++ b/games/BubblePopOrderGame.jsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableWithoutFeedback, Animated, StyleSheet, Dimensions } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import themeVariables from '../styles/theme';
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+const BubblePopOrderGame = ({ quote, onBack }) => {
+  const text = typeof quote === 'string' ? quote : quote?.text || '';
+  const words = text.split(/\s+/);
+  const [index, setIndex] = useState(0);
+  const [message, setMessage] = useState('');
+  const [bubbles, setBubbles] = useState([]);
+
+  // initialize bubbles
+  useEffect(() => {
+    const items = words.map((w, i) => {
+      const startX = Math.random() * (SCREEN_WIDTH - 80);
+      const startY = Math.random() * (SCREEN_HEIGHT / 2) + SCREEN_HEIGHT / 4;
+      const floatAnim = new Animated.Value(0);
+      const scale = new Animated.Value(1);
+      Animated.loop(
+        Animated.sequence([
+          Animated.timing(floatAnim, {
+            toValue: -10,
+            duration: 2000 + Math.random() * 1000,
+            useNativeDriver: true,
+          }),
+          Animated.timing(floatAnim, {
+            toValue: 10,
+            duration: 2000 + Math.random() * 1000,
+            useNativeDriver: true,
+          }),
+          Animated.timing(floatAnim, {
+            toValue: 0,
+            duration: 2000 + Math.random() * 1000,
+            useNativeDriver: true,
+          }),
+        ]),
+      ).start();
+      return { word: w, id: i, x: startX, y: startY, floatAnim, scale, popped: false };
+    });
+    setBubbles(items);
+    setIndex(0);
+    setMessage('');
+  }, [text]);
+
+  const handlePress = (id) => {
+    setBubbles((prev) => {
+      const updated = prev.map((b) => {
+        if (b.id !== id) return b;
+        if (b.popped) return b;
+        if (b.word === words[index]) {
+          Animated.timing(b.scale, { toValue: 0, duration: 200, useNativeDriver: true }).start();
+          b.popped = true;
+          const next = index + 1;
+          setIndex(next);
+          if (next === words.length) setMessage('Great job!');
+          else setMessage('');
+        } else {
+          Animated.sequence([
+            Animated.timing(b.scale, { toValue: 0.5, duration: 150, useNativeDriver: true }),
+            Animated.timing(b.scale, { toValue: 1, duration: 150, useNativeDriver: true }),
+          ]).start();
+          setMessage('Try again');
+        }
+        return b;
+      });
+      return [...updated];
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <Text style={styles.title}>Bubble Pop Order</Text>
+      <Text style={styles.description}>Pop the words in the correct order.</Text>
+      {bubbles.map((b) =>
+        !b.popped && (
+          <TouchableWithoutFeedback key={b.id} onPress={() => handlePress(b.id)}>
+            <Animated.View
+              style={[
+                styles.bubble,
+                {
+                  left: b.x,
+                  top: b.y,
+                  transform: [{ translateY: b.floatAnim }, { scale: b.scale }],
+                },
+              ]}
+            >
+              <Text style={styles.word}>{b.word}</Text>
+            </Animated.View>
+          </TouchableWithoutFeedback>
+        ),
+      )}
+      {message !== '' && <Text style={styles.message}>{message}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: themeVariables.neutralLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 28,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  bubble: {
+    position: 'absolute',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: themeVariables.primaryLightColor,
+    borderRadius: 30,
+    borderWidth: 1,
+    borderColor: themeVariables.primaryColor,
+  },
+  word: {
+    color: themeVariables.primaryColorDark,
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+  message: {
+    fontSize: 18,
+    color: themeVariables.primaryColor,
+    marginTop: 12,
+  },
+});
+
+export default BubblePopOrderGame;

--- a/games/gameRoutes.js
+++ b/games/gameRoutes.js
@@ -18,6 +18,7 @@ import MemoryMazeGame from './MemoryMazeGame';
 import SceneChangeGame from './SceneChangeGame';
 import WordSwapGame from './WordSwapGame';
 import BuildRecallGame from './BuildRecallGame';
+import BubblePopOrderGame from './BubblePopOrderGame';
 
 export const gameScreens = {
   practice: QuotePracticeScreen,
@@ -40,4 +41,5 @@ export const gameScreens = {
   sceneChangeGame: SceneChangeGame,
   wordSwapGame: WordSwapGame,
   buildRecallGame: BuildRecallGame,
+  bubblePopOrderGame: BubblePopOrderGame,
 };

--- a/games/index.js
+++ b/games/index.js
@@ -6,6 +6,7 @@ export const gameIds = [
   'memoryGame',
   'shapeBuilderGame',
   'hangmanGame',
+  'bubblePopOrderGame',
   // 'practice',
   // 'tapGame',
   // 'scrambleGame',

--- a/screens/GamesListScreen.jsx
+++ b/screens/GamesListScreen.jsx
@@ -39,6 +39,7 @@ const titles = {
   sceneChangeGame: 'Scene Change',
   wordSwapGame: 'Word Swap',
   buildRecallGame: 'Build & Recall',
+  bubblePopOrderGame: 'Bubble Pop Order',
 };
 const iconMap = {
   practice: 'book-outline',
@@ -61,6 +62,7 @@ const iconMap = {
   sceneChangeGame: 'images-outline',
   wordSwapGame: 'swap-horizontal-outline',
   buildRecallGame: 'build-outline',
+  bubblePopOrderGame: 'water-outline',
 };
 
 const GamesListScreen = ({ onSelect }) => (


### PR DESCRIPTION
## Summary
- implement `BubblePopOrderGame` with animated drifting bubbles
- register game in routes and game list
- expose game ID in registry for selection
- allow navigation to new game via MainApp

## Testing
- `npm test` *(fails: No instances found with props {label:"Liquid Spirit"})*

------
https://chatgpt.com/codex/tasks/task_e_6875f0f25ea88328a2dc005993487923