### PR TITLE
Secure login fields with keychain

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -9,10 +9,20 @@ jest.mock(
   () => ({
     getItem: jest.fn(() => Promise.resolve(null)),
     setItem: jest.fn(() => Promise.resolve()),
+    getAllKeys: jest.fn(() => Promise.resolve([])),
+    multiGet: jest.fn(() => Promise.resolve([])),
+    removeItem: jest.fn(() => Promise.resolve()),
+    multiRemove: jest.fn(() => Promise.resolve()),
   }),
   { virtual: true },
 );
- jest.mock('react-native-config', () => ({ DEV_API: 'http://localhost' }));
+jest.mock('react-native-config', () => ({ DEV_API: 'http://localhost' }));
+jest.mock('react-native-fast-image', () => {
+  const React = require('react');
+  const FastImage = props => React.createElement('FastImage', props);
+  FastImage.preload = jest.fn();
+  return FastImage;
+}, { virtual: true });
 // Mock external styleguide UI library
 jest.mock('liquid-spirit-styleguide', () => {
   const React = require('react');

--- a/__tests__/NuriLoginScreen.test.js
+++ b/__tests__/NuriLoginScreen.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(() => Promise.resolve(null)),
+  setItem: jest.fn(() => Promise.resolve()),
+  getAllKeys: jest.fn(() => Promise.resolve([])),
+  multiGet: jest.fn(() => Promise.resolve([])),
+  removeItem: jest.fn(() => Promise.resolve()),
+  multiRemove: jest.fn(() => Promise.resolve()),
+}), { virtual: true });
+jest.mock('react-native-config', () => ({ DEV_API: 'http://localhost' }));
+jest.mock('react-native-keychain', () => ({
+  getGenericPassword: jest.fn(() => Promise.resolve({ username: 'user@example.com', password: 'secret' })),
+  setGenericPassword: jest.fn(() => Promise.resolve()),
+}), { virtual: true });
+
+import NuriLoginScreen from '../screens/NuriLoginScreen.jsx';
+
+it('prefills stored credentials', async () => {
+  let instance;
+  await ReactTestRenderer.act(async () => {
+    instance = ReactTestRenderer.create(<NuriLoginScreen onSignIn={jest.fn()} />);
+  });
+  const emailInput = instance.root.findByProps({ placeholder: 'Email' });
+  const passInput = instance.root.findByProps({ placeholder: 'Password' });
+  expect(emailInput.props.value).toBe('user@example.com');
+  expect(passInput.props.value).toBe('secret');
+});

--- a/__tests__/authFlow.test.js
+++ b/__tests__/authFlow.test.js
@@ -46,7 +46,7 @@ describe('WelcomeScreen sign in navigation', () => {
       instance = ReactTestRenderer.create(<WelcomeScreen navigation={{ navigate }} />);
     });
     ReactTestRenderer.act(() => {
-      instance.root.findByProps({ label: 'Liquid Spirit' }).props.onPress();
+      instance.root.findByType(require('react-native').TouchableOpacity).props.onPress();
     });
     expect(navigate).toHaveBeenCalledWith('LSLogin');
   });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -26,3 +26,8 @@ jest.mock('react-native-tts', () => ({
   speak: jest.fn(),
   stop: jest.fn(),
 }));
+jest.mock('react-native-keychain', () => ({
+  getGenericPassword: jest.fn(() => Promise.resolve(null)),
+  setGenericPassword: jest.fn(() => Promise.resolve()),
+  resetGenericPassword: jest.fn(() => Promise.resolve()),
+}), { virtual: true });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-native-pager-view": "^6.8.1",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.11.1",
+    "react-native-keychain": "^9.2.0",
     "react-native-svg": "12.3.0",
     "react-native-tab-view": "^4.1.2",
     "react-native-tts": "^4.1.1",

--- a/screens/LiquidSpiritLoginScreen.jsx
+++ b/screens/LiquidSpiritLoginScreen.jsx
@@ -1,15 +1,28 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { Button } from 'liquid-spirit-styleguide';
 import { signInWithLiquidSpirit } from '../services/authService';
+import { loadCredentials, saveCredentials } from '../services/credentialService';
 
 export default function LiquidSpiritLoginScreen({ onSignIn }) {
   const [bahaiId, setBahaiId] = useState('');
   const [password, setPassword] = useState('');
   const [email, setEmail] = useState('');
 
+  useEffect(() => {
+    const fetchCredentials = async () => {
+      const creds = await loadCredentials();
+      if (creds) {
+        setEmail(creds.email);
+        setPassword(creds.password);
+      }
+    };
+    fetchCredentials();
+  }, []);
+
   const handleLogin = async () => {
     try {
+      await saveCredentials(email, password);
       const data = await signInWithLiquidSpirit(bahaiId, email, password);
       onSignIn(data);
     } catch (err) {

--- a/screens/NuriLoginScreen.jsx
+++ b/screens/NuriLoginScreen.jsx
@@ -1,14 +1,27 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { Button } from 'liquid-spirit-styleguide';
 import { loginNuriUser } from '../services/authService';
+import { loadCredentials, saveCredentials } from '../services/credentialService';
 
 export default function NuriLoginScreen({ onSignIn, navigation }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
+  useEffect(() => {
+    const fetchCredentials = async () => {
+      const creds = await loadCredentials();
+      if (creds) {
+        setEmail(creds.email);
+        setPassword(creds.password);
+      }
+    };
+    fetchCredentials();
+  }, []);
+
   const handleLogin = async () => {
     try {
+      await saveCredentials(email, password);
       const data = await loginNuriUser(email, password);
       onSignIn(data);
     } catch (err) {

--- a/services/credentialService.js
+++ b/services/credentialService.js
@@ -1,0 +1,29 @@
+import * as Keychain from 'react-native-keychain';
+
+export const saveCredentials = async (email, password) => {
+  try {
+    await Keychain.setGenericPassword(email, password);
+  } catch (e) {
+    console.warn('Failed to save credentials', e);
+  }
+};
+
+export const loadCredentials = async () => {
+  try {
+    const creds = await Keychain.getGenericPassword();
+    if (creds) {
+      return { email: creds.username, password: creds.password };
+    }
+  } catch (e) {
+    console.warn('Failed to load credentials', e);
+  }
+  return { email: '', password: '' };
+};
+
+export const clearCredentials = async () => {
+  try {
+    await Keychain.resetGenericPassword();
+  } catch (e) {
+    console.warn('Failed to clear credentials', e);
+  }
+};


### PR DESCRIPTION
## Summary
- add `react-native-keychain` dependency
- create `credentialService` for storing credentials
- preload saved email/password in login screens
- update tests and add test for credential prefill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878e65534fc83289e13879aba398fc7