### PR TITLE
Add service to grant achievements from game wins

### DIFF
--- a/components/GameRenderer.jsx
+++ b/components/GameRenderer.jsx
@@ -3,20 +3,14 @@ import { View } from 'react-native';
 import { gameScreens } from '../games/gameRoutes';
 import DifficultyFAB from './DifficultyFAB';
 
-const GameRenderer = ({ screen, quote, onBack, level, awardAchievement }) => {
+const GameRenderer = ({ screen, quote, onBack, level, awardGameAchievement }) => {
   const GameComponent = gameScreens[screen];
   if (!GameComponent) return null;
   const gameProps = { quote, onBack };
-  if (screen === 'memoryGame') {
-    gameProps.onWin = () => awardAchievement(`memory${level}`);
-  } else if (screen === 'shapeBuilderGame') {
-    gameProps.onWin = () => awardAchievement(`shape${level}`);
-  } else if (screen === 'hangmanGame') {
-    gameProps.onWin = () => awardAchievement(`hangman${level}`);
-  } else if (screen === 'bubblePopOrderGame') {
-    // Award achievement based on bubble pop difficulty
-    gameProps.onWin = () => awardAchievement(`bubble${level}`);
-    // Pass difficulty level to bubble pop game for tap limit
+  // Handle game win for all games via service mapping
+  gameProps.onWin = () => awardGameAchievement(screen, level);
+  // Some games need the level passed through
+  if (screen === 'bubblePopOrderGame') {
     gameProps.level = level;
   }
   return (

--- a/components/MainApp.jsx
+++ b/components/MainApp.jsx
@@ -56,7 +56,7 @@ const MainApp = () => {
   } = useProfile();
   const { nav, goTo, visitGrade } = useNavigationHandlers();
   const achievementsState = useAchievements(profile, saveProfile);
-  const { achievements, notification, setNotification, awardAchievement } = achievementsState;
+  const { achievements, notification, setNotification, awardAchievement, awardGameAchievement } = achievementsState;
   // Pass profile to lesson progress hook to adjust defaults by grade
   const { completedLessons, overrideProgress, setOverrideProgress, completeLesson, getCurrentProgress } = useLessonProgress(profile, awardAchievement);
   const [chooseChildVisible, setChooseChildVisible] = useState(false);
@@ -194,7 +194,15 @@ const MainApp = () => {
     }
     if (['practice', 'tapGame', 'scrambleGame', 'nextWordGame', 'memoryGame', 'flashGame', 'revealGame', 'firstLetterGame', 'letterScrambleGame', 'fastTypeGame', 'hangmanGame', 'fillBlankGame', 'shapeBuilderGame', 'colorSwitchGame', 'rhythmRepeatGame', 'silhouetteSearchGame', 'memoryMazeGame', 'sceneChangeGame', 'wordSwapGame', 'buildRecallGame', 'bubblePopOrderGame'].includes(nav.screen)) {
       const backHandler = nav.fromGames ? goHome : goBackToLesson;
-      return <GameRenderer screen={nav.screen} quote={nav.quote} onBack={backHandler} level={level} awardAchievement={awardAchievement} />;
+      return (
+        <GameRenderer
+          screen={nav.screen}
+          quote={nav.quote}
+          onBack={backHandler}
+          level={level}
+          awardGameAchievement={awardGameAchievement}
+        />
+      );
     }
     switch (nav.screen) {
       case 'grade1':

--- a/contexts/AchievementsContext.jsx
+++ b/contexts/AchievementsContext.jsx
@@ -5,6 +5,7 @@ const AchievementsContext = createContext({
   notification: null,
   setNotification: () => {},
   awardAchievement: () => {},
+  awardGameAchievement: () => {},
 });
 
 export const AchievementsProvider = ({ value, children }) => (

--- a/services/achievementGrantService.js
+++ b/services/achievementGrantService.js
@@ -1,0 +1,79 @@
+import { updateAchievementOnServer } from './achievementsService';
+
+// Map of game screen to achievement IDs by difficulty level
+const GAME_ACHIEVEMENT_MAP = {
+  memoryGame: { 1: 'memory1', 2: 'memory2', 3: 'memory3' },
+  shapeBuilderGame: { 1: 'shape1', 2: 'shape2', 3: 'shape3' },
+  hangmanGame: { 1: 'hangman1', 2: 'hangman2', 3: 'hangman3' },
+  bubblePopOrderGame: { 1: 'bubble1', 2: 'bubble2', 3: 'bubble3' },
+};
+
+export function getAchievementIdForGame(screen, level) {
+  return GAME_ACHIEVEMENT_MAP[screen]?.[level] || null;
+}
+
+/**
+ * Call server to grant achievement, then update local context/profile.
+ * @param {Object} opts
+ * @param {string} opts.id - Achievement ID to grant
+ * @param {Object} opts.profile - Current user profile
+ * @param {Array} opts.achievements - Current achievements array
+ * @param {Function} opts.setAchievements - Setter from AchievementsContext
+ * @param {Function} opts.setNotification - Setter for notification banner
+ * @param {Function} opts.saveProfile - Persists profile to storage
+ */
+export async function grantAchievement({
+  id,
+  profile,
+  achievements,
+  setAchievements,
+  setNotification,
+  saveProfile,
+}) {
+  if (!profile || !id) return;
+
+  // Avoid duplicate awards
+  const alreadyEarned = achievements.some(a => a.id === id && a.earned);
+  if (alreadyEarned) return;
+
+  try {
+    const userId = profile._id || profile.id || profile.nuriUserId;
+    const { user } = await updateAchievementOnServer(userId, id);
+
+    // Normalise server achievements into client shape
+    const updatedAchievements = user.achievements.map(a => ({
+      id: a.achievement._id,
+      title: a.achievement.title,
+      points: a.achievement.points,
+      earned: true,
+    }));
+
+    // Persist profile and update context
+    const updatedProfile = {
+      ...profile,
+      achievements: updatedAchievements,
+      totalPoints: user.totalPoints,
+    };
+    setAchievements(updatedAchievements);
+    saveProfile(updatedProfile);
+
+    const earned = updatedAchievements.find(a => a.id === id);
+    if (earned) {
+      setNotification({ id: earned.id, title: earned.title });
+    }
+  } catch (e) {
+    console.error('grantAchievement error:', e);
+  }
+}
+
+/**
+ * Convenience wrapper for game wins. Determines which achievement to award
+ * based on game screen and difficulty level.
+ */
+export async function grantGameAchievement(opts) {
+  const { screen, level } = opts;
+  const id = getAchievementIdForGame(screen, level);
+  if (!id) return;
+  await grantAchievement({ ...opts, id });
+}
+


### PR DESCRIPTION
## Summary
- Create achievementGrantService to map game wins to achievement IDs and sync with server
- Update achievements hook and context to use server-first grant logic
- Wire game renderer and main app to new service for awarding achievements on win

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6894355e05888328a1fa3dee4241afc0