### PR TITLE
Add lesson journey tracking screen

### DIFF
--- a/components/MainApp.jsx
+++ b/components/MainApp.jsx
@@ -22,6 +22,7 @@ import {
   Splash,
   GamesListScreen,
   ClassScreen,
+  LessonJourneyScreen,
 } from '../screens';
 import AuthNavigator from '../navigation/AuthNavigator';
 import BottomNav from '../navigation/BottomNav';
@@ -213,13 +214,18 @@ const MainApp = () => {
           />
         );
       case 'grade1Lesson':
-        return <Grade1LessonScreen lessonNumber={nav.lessonNumber} onBack={() => goTo('grade1')} />;
+        return (
+          <Grade1LessonScreen
+            lessonNumber={nav.lessonNumber}
+            onBack={nav.from === 'journey' ? () => goTo('lessonJourney') : () => goTo('grade1')}
+          />
+        );
       case 'grade2Lesson':
         return (
           <Grade2LessonScreen
             setNumber={nav.setNumber}
             lessonNumber={nav.lessonNumber}
-            onBack={goBackToGrade2Set}
+            onBack={nav.from === 'journey' ? () => goTo('lessonJourney') : goBackToGrade2Set}
             onComplete={completeLesson}
             onPractice={(q) => goTo('practice', { quote: q })}
             onPlayGame={(q) => goTo('tapGame', { quote: q })}
@@ -230,7 +236,7 @@ const MainApp = () => {
           <Grade2bLessonScreen
             setNumber={nav.setNumber}
             lessonNumber={nav.lessonNumber}
-            onBack={goBackToGrade2bSet}
+            onBack={nav.from === 'journey' ? () => goTo('lessonJourney') : goBackToGrade2bSet}
             onComplete={completeLesson}
             onPractice={(q) => goTo('practice', { quote: q })}
             onPlayGame={(q) => goTo('tapGame', { quote: q })}
@@ -273,6 +279,24 @@ const MainApp = () => {
         );
       case 'class':
         return <ClassScreen childEntries={children || []} onBack={goHome} />;
+      case 'lessonJourney':
+        return (
+          <LessonJourneyScreen
+            profile={profile}
+            currentProgress={getCurrentProgress()}
+            completedLessons={completedLessons}
+            onBack={goHome}
+            goToLesson={(setNumber, lessonNumber) => {
+              if (profile.grade === 1) {
+                goTo('grade1Lesson', { lessonNumber, from: 'journey' });
+              } else if (profile.grade === 2) {
+                goTo('grade2Lesson', { setNumber, lessonNumber, from: 'journey' });
+              } else if (profile.grade === '2b') {
+                goTo('grade2bLesson', { setNumber, lessonNumber, from: 'journey' });
+              }
+            }}
+          />
+        );
       case 'grades':
         return (
           <GradesScreen
@@ -321,6 +345,7 @@ const MainApp = () => {
             currentLesson={lessonNumber}
             onProfilePress={() => setChooseChildVisible(true)}
             onAvatarPress={handleAvatarPress}
+            onJourney={() => goTo('lessonJourney')}
           />
         );
       }

--- a/screens/HomeScreen.jsx
+++ b/screens/HomeScreen.jsx
@@ -18,6 +18,7 @@ const HomeScreen = ({
   currentLesson,
   onProfilePress,
   onAvatarPress,
+  onJourney,
 }) => {
   console.log('HomeScreen achievements:', achievements);
   // Determine prayer and quote based on grade and progress
@@ -84,6 +85,10 @@ const HomeScreen = ({
 
       {/* Action Buttons */}
       <View style={styles.bottomButtonContainer}>
+        <TouchableOpacity style={styles.customButton} onPress={onJourney}>
+          <Text style={styles.customButtonText}>Lesson Journey</Text>
+          <Ionicons name="arrow-forward" size={20} color="white" />
+        </TouchableOpacity>
         <TouchableOpacity style={styles.customButton} onPress={onDailyChallenge}>
           <Text style={styles.customButtonText}>Daily Challenge</Text>
           <Ionicons name="arrow-forward" size={20} color="white" />

--- a/screens/LessonJourneyScreen.jsx
+++ b/screens/LessonJourneyScreen.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import themeVariables from '../styles/theme';
+
+const LessonJourneyScreen = ({ profile, currentProgress, completedLessons, onBack, goToLesson }) => {
+  const grade = profile?.grade;
+  const { setNumber, lessonNumber } = currentProgress || {};
+
+  const renderGrade1 = () => {
+    const lessons = Array.from({ length: lessonNumber || 0 }, (_, i) => i + 1);
+    return (
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Lessons</Text>
+        <View style={styles.lessonList}>
+          {lessons.map(l => (
+            <TouchableOpacity key={l} style={styles.lessonButton} onPress={() => goToLesson(null, l)}>
+              <Text style={styles.lessonText}>Lesson {l}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+    );
+  };
+
+  const renderGrade2 = () => {
+    const currentSet = setNumber || 1;
+    const startSet = Math.max(1, currentSet - 1);
+    const sets = [];
+    for (let s = startSet; s <= currentSet; s++) {
+      const lessons = [1, 2, 3];
+      sets.push(
+        <View key={s} style={styles.section}>
+          <Text style={styles.sectionTitle}>Set {s}</Text>
+          <View style={styles.lessonRow}>
+            {lessons.map(l => {
+              const completed = completedLessons[s]?.[l];
+              const isCurrent = s === currentSet && l === lessonNumber;
+              return (
+                <TouchableOpacity
+                  key={l}
+                  style={[styles.lessonCircle, completed && styles.completed, isCurrent && styles.current]}
+                  onPress={() => goToLesson(s, l)}
+                >
+                  <Text style={styles.lessonText}>{l}</Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
+      );
+    }
+    return sets;
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Lesson Journey</Text>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        {grade === 1 && renderGrade1()}
+        {grade === 2 && renderGrade2()}
+        {grade === '2b' && renderGrade2()}
+      </ScrollView>
+      <TouchableOpacity style={styles.backButton} onPress={onBack}>
+        <Text style={styles.backButtonText}>Back</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    alignItems: 'center',
+    backgroundColor: themeVariables.primaryColor,
+  },
+  title: {
+    fontSize: 24,
+    color: themeVariables.whiteColor,
+    marginBottom: 16,
+  },
+  scrollContent: {
+    alignItems: 'center',
+    paddingBottom: 24,
+  },
+  section: {
+    marginBottom: 24,
+    alignItems: 'center',
+  },
+  sectionTitle: {
+    fontSize: 20,
+    color: themeVariables.whiteColor,
+    marginBottom: 12,
+  },
+  lessonList: {
+    width: '100%',
+    alignItems: 'center',
+  },
+  lessonButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderWidth: 1,
+    borderColor: themeVariables.whiteColor,
+    borderRadius: themeVariables.borderRadiusPill,
+    marginBottom: 8,
+  },
+  lessonRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  lessonCircle: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    borderWidth: 1,
+    borderColor: themeVariables.whiteColor,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  lessonText: {
+    color: themeVariables.whiteColor,
+    fontSize: 16,
+  },
+  completed: {
+    backgroundColor: themeVariables.secondaryColor,
+  },
+  current: {
+    borderColor: themeVariables.tertiaryColor,
+    borderWidth: 2,
+  },
+  backButton: {
+    marginTop: 'auto',
+    width: '80%',
+    backgroundColor: themeVariables.primaryLightColor,
+    paddingVertical: 12,
+    borderRadius: themeVariables.borderRadiusPill,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  backButtonText: {
+    color: themeVariables.whiteColor,
+    fontSize: 16,
+  },
+});
+
+export default LessonJourneyScreen;
+

--- a/screens/index.js
+++ b/screens/index.js
@@ -22,3 +22,4 @@ export { default as GamesListScreen } from './GamesListScreen';
 export { default as ClassScreen } from './ClassScreen';
 export { default as NuriRegisterScreen } from './NuriRegisterScreen';
 export { default as NuriLoginScreen } from './NuriLoginScreen';
+export { default as LessonJourneyScreen } from './LessonJourneyScreen';


### PR DESCRIPTION
## Summary
- add LessonJourneyScreen to show current and previous lessons for review
- link journey screen from Home and navigation
- allow lessons to return to journey when revisiting

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'typescript')*


------
https://chatgpt.com/codex/tasks/task_e_68947656e7c88328bb929db5fff9fe73