### PR TITLE
feat: add Word Racer car game with achievements

### DIFF
--- a/ACHIEVEMENTS.md
+++ b/ACHIEVEMENTS.md
@@ -1,0 +1,41 @@
+# Achievements
+
+| ID | Title | Description | Points |
+|---|---|---|---|
+| daily | Daily Learner | Do a memorisation game each day | 5 |
+| set1 | Set 1 Master | Complete all lessons in Set 1 | 10 |
+| prayer1 | Prayer Beginner | Memorise your first prayer | 5 |
+| prayer5 | Prayer Enthusiast | Memorise five prayers | 15 |
+| prayer10 | Prayer Expert | Memorise ten prayers | 25 |
+| quote1 | Quote Starter | Memorise your first quote | 5 |
+| quote5 | Quote Collector | Memorise five quotes | 15 |
+| quote15 | Quote Scholar | Memorise fifteen quotes | 25 |
+| set2 | Set 2 Master | Complete all lessons in Set 2 | 10 |
+| set3 | Set 3 Master | Complete all lessons in Set 3 | 10 |
+| set4 | Set 4 Master | Complete all lessons in Set 4 | 10 |
+| grade1 | Grade 1 Star | Finish all Grade 1 lessons | 20 |
+| grade2 | Grade 2 Star | Finish all Grade 2 lessons | 25 |
+| streak3 | Daily Streak 3 | Do the daily challenge three days in a row | 5 |
+| streak7 | Daily Streak 7 | Do the daily challenge seven days in a row | 15 |
+| streak30 | Daily Streak 30 | Do the daily challenge thirty days in a row | 30 |
+| game1 | Game Beginner | Play your first game | 5 |
+| game10 | Game Fanatic | Play ten games | 20 |
+| practice20 | Quote Practice Pro | Practice quotes twenty times | 10 |
+| tapPerfect | Tap Game Champ | Finish a tap game without mistakes | 15 |
+| profile | Profile Setup | Create your profile and avatar | 5 |
+| explorer | Class Explorer | Visit all grade levels | 10 |
+| memory1 | Memory Match Novice | Complete Memory Match on Easy (4x4) difficulty | 5 |
+| memory2 | Memory Match Intermediate | Complete Memory Match on Medium (5x5) difficulty | 10 |
+| memory3 | Memory Match Master | Complete Memory Match on Hard (6x6) difficulty | 15 |
+| shape1 | Shape Builder Novice | Complete Shape Builder on Easy difficulty | 5 |
+| shape2 | Shape Builder Intermediate | Complete Shape Builder on Medium difficulty | 10 |
+| shape3 | Shape Builder Master | Complete Shape Builder on Hard difficulty | 15 |
+| hangman1 | Hangman Novice | Win Hangman on Easy difficulty | 5 |
+| hangman2 | Hangman Intermediate | Win Hangman on Medium difficulty | 10 |
+| hangman3 | Hangman Master | Win Hangman on Hard difficulty | 15 |
+| bubble1 | Bubble Pop Novice | Complete Bubble Pop Order on Easy difficulty | 5 |
+| bubble2 | Bubble Pop Intermediate | Complete Bubble Pop Order on Medium difficulty | 10 |
+| bubble3 | Bubble Pop Master | Complete Bubble Pop Order on Hard difficulty | 15 |
+| wordRacer1 | Word Racer Novice | Complete Word Racer on Easy difficulty | 5 |
+| wordRacer2 | Word Racer Intermediate | Complete Word Racer on Medium difficulty | 10 |
+| wordRacer3 | Word Racer Master | Complete Word Racer on Hard difficulty | 15 |

--- a/__tests__/WordRacerGame.test.js
+++ b/__tests__/WordRacerGame.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import WordRacerGame from '../games/WordRacerGame';
+import { gameIds } from '../games';
+import { achievements } from '../data/achievements';
+
+describe('WordRacerGame', () => {
+  it('exports a component', () => {
+    expect(typeof WordRacerGame).toBe('function');
+  });
+
+  it('is registered in game ids', () => {
+    expect(gameIds).toContain('wordRacerGame');
+  });
+
+  it('has achievements defined', () => {
+    const ids = achievements.map((a) => a.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(['wordRacer1', 'wordRacer2', 'wordRacer3']),
+    );
+  });
+});

--- a/data/achievements.js
+++ b/data/achievements.js
@@ -298,4 +298,31 @@ export const achievements = [
     prereq: 'bubble2',
     earned: false,
   },
+  // Word Racer achievements by difficulty
+  {
+    id: 'wordRacer1',
+    title: 'Word Racer Novice',
+    description: 'Complete Word Racer on Easy difficulty',
+    icon: 'trophy',
+    points: 5,
+    earned: false,
+  },
+  {
+    id: 'wordRacer2',
+    title: 'Word Racer Intermediate',
+    description: 'Complete Word Racer on Medium difficulty',
+    icon: 'trophy',
+    points: 10,
+    prereq: 'wordRacer1',
+    earned: false,
+  },
+  {
+    id: 'wordRacer3',
+    title: 'Word Racer Master',
+    description: 'Complete Word Racer on Hard difficulty',
+    icon: 'trophy',
+    points: 15,
+    prereq: 'wordRacer2',
+    earned: false,
+  },
 ];

--- a/games/WordRacerGame.jsx
+++ b/games/WordRacerGame.jsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import GameTopBar from '../components/GameTopBar';
+import ThemedButton from '../components/ThemedButton';
+import themeVariables from '../styles/theme';
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const CAR_SIZE = 40;
+const STEP = 20;
+
+const WordRacerGame = ({ quote, onBack, onWin }) => {
+  const sentence = typeof quote === 'string' ? quote : quote?.text || '';
+  const [car, setCar] = useState({
+    x: SCREEN_WIDTH / 2 - CAR_SIZE / 2,
+    y: SCREEN_HEIGHT / 2 - CAR_SIZE / 2,
+  });
+  const [words, setWords] = useState([]);
+  const [collected, setCollected] = useState([]);
+
+  useEffect(() => {
+    const w = sentence.split(/\s+/).map((text) => ({
+      text,
+      x: Math.random() * (SCREEN_WIDTH - 60) + 30,
+      y: Math.random() * (SCREEN_HEIGHT - 200) + 100,
+    }));
+    setWords(w);
+    setCollected([]);
+    setCar({ x: SCREEN_WIDTH / 2 - CAR_SIZE / 2, y: SCREEN_HEIGHT / 2 - CAR_SIZE / 2 });
+  }, [quote, sentence]);
+
+  const checkCollision = (x, y) => {
+    setWords((prev) => {
+      const remaining = [];
+      const newlyCollected = [];
+      prev.forEach((w) => {
+        if (Math.abs(w.x - x) < 30 && Math.abs(w.y - y) < 30) {
+          newlyCollected.push(w.text);
+        } else {
+          remaining.push(w);
+        }
+      });
+      if (newlyCollected.length) {
+        setCollected((c) => [...c, ...newlyCollected]);
+      }
+      return remaining;
+    });
+  };
+
+  const move = (dx, dy) => {
+    setCar((prev) => {
+      const nx = Math.max(0, Math.min(SCREEN_WIDTH - CAR_SIZE, prev.x + dx));
+      const ny = Math.max(0, Math.min(SCREEN_HEIGHT - CAR_SIZE, prev.y + dy));
+      checkCollision(nx, ny);
+      return { x: nx, y: ny };
+    });
+  };
+
+  useEffect(() => {
+    if (words.length === 0 && sentence) {
+      onWin?.();
+    }
+  }, [words, sentence, onWin]);
+
+  return (
+    <View style={styles.container}>
+      <GameTopBar onBack={onBack} />
+      <View style={[styles.car, { left: car.x, top: car.y }]}>
+        <Text style={styles.carText}>🚗</Text>
+      </View>
+      {words.map((w) => (
+        <Text key={w.text + w.x} style={[styles.word, { left: w.x, top: w.y }]}> 
+          {w.text}
+        </Text>
+      ))}
+      <View style={styles.controls}>
+        <ThemedButton title="↑" onPress={() => move(0, -STEP)} style={styles.controlBtn} />
+        <View style={styles.horizontal}>
+          <ThemedButton title="←" onPress={() => move(-STEP, 0)} style={styles.controlBtn} />
+          <ThemedButton title="→" onPress={() => move(STEP, 0)} style={styles.controlBtn} />
+        </View>
+        <ThemedButton title="↓" onPress={() => move(0, STEP)} style={styles.controlBtn} />
+      </View>
+      <Text style={styles.collected}>{collected.join(' ')}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: themeVariables.whiteColor },
+  car: {
+    position: 'absolute',
+    width: CAR_SIZE,
+    height: CAR_SIZE,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  carText: { fontSize: 32 },
+  word: { position: 'absolute', fontSize: 16, color: themeVariables.textColor },
+  controls: {
+    position: 'absolute',
+    bottom: 20,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  horizontal: { flexDirection: 'row', marginVertical: 8 },
+  controlBtn: { minWidth: 60, marginHorizontal: 10 },
+  collected: {
+    position: 'absolute',
+    top: 60,
+    left: 20,
+    right: 20,
+    fontSize: 18,
+    textAlign: 'center',
+    color: themeVariables.textColor,
+  },
+});
+
+export default WordRacerGame;

--- a/games/gameRoutes.js
+++ b/games/gameRoutes.js
@@ -19,6 +19,7 @@ import SceneChangeGame from './SceneChangeGame';
 import WordSwapGame from './WordSwapGame';
 import BuildRecallGame from './BuildRecallGame';
 import BubblePopOrderGame from './BubblePopOrderGame';
+import WordRacerGame from './WordRacerGame';
 
 export const gameScreens = {
   practice: QuotePracticeScreen,
@@ -42,4 +43,5 @@ export const gameScreens = {
   wordSwapGame: WordSwapGame,
   buildRecallGame: BuildRecallGame,
   bubblePopOrderGame: BubblePopOrderGame,
+  wordRacerGame: WordRacerGame,
 };

--- a/games/index.js
+++ b/games/index.js
@@ -7,6 +7,7 @@ export const gameIds = [
   'shapeBuilderGame',
   'hangmanGame',
   'bubblePopOrderGame',
+  'wordRacerGame',
   // 'practice',
   // 'tapGame',
   // 'scrambleGame',

--- a/games/lazyGameRoutes.js
+++ b/games/lazyGameRoutes.js
@@ -24,5 +24,6 @@ export const lazyGameScreens = {
   wordSwapGame: lazy(() => import('./WordSwapGame')),
   buildRecallGame: lazy(() => import('./BuildRecallGame')),
   bubblePopOrderGame: lazy(() => import('./BubblePopOrderGame')),
+  wordRacerGame: lazy(() => import('./WordRacerGame')),
 };
 


### PR DESCRIPTION
## Summary
- add Word Racer car platformer collecting words to form sentences
- register new game and achievements, generated ACHIEVEMENTS.md
- cover new game and achievements with tests

## Testing
- `npm run lint` *(fails: React Hook useEffect has missing dependencies in screens/SettingsScreen.jsx)*
- `npx eslint games/WordRacerGame.jsx games/gameRoutes.js games/lazyGameRoutes.js games/index.js data/achievements.js __tests__/WordRacerGame.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b81ffd4c83288f677aaf6755d029