### PR TITLE
feat: improve ShapeBuilder puzzle visuals

### DIFF
--- a/components/PuzzlePieceSvg.jsx
+++ b/components/PuzzlePieceSvg.jsx
@@ -92,6 +92,11 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     overflow: 'visible',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 1.5,
+    elevation: 3,
   },
   svgWrap: {
     flex: 1,

--- a/components/PuzzleSlotSvg.jsx
+++ b/components/PuzzleSlotSvg.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import Svg, { Path } from 'react-native-svg';
-import themeVariables from '../styles/theme';
+import Svg, { Path, Defs, LinearGradient, Stop, ClipPath, G } from 'react-native-svg';
 import { buildJigsawPath } from './PuzzlePath';
 
 const PuzzleSlotSvg = ({ left, top, size, connectors }) => {
@@ -9,8 +8,11 @@ const PuzzleSlotSvg = ({ left, top, size, connectors }) => {
   const knobRatio = 0.22;
   const pad = Math.round(size * knobRatio);
   const d = buildJigsawPath(size, connectors, knobRatio);
+  const gradId = useMemo(() => `slot_grad_${Math.random().toString(36).slice(2)}`, []);
+  const clipId = useMemo(() => `slot_clip_${Math.random().toString(36).slice(2)}`, []);
   return (
-    <View style={[styles.container, { left, top, width: size, height: size }]}
+    <View
+      style={[styles.container, { left, top, width: size, height: size }, styles.shadow]}
       pointerEvents="none"
     >
       <Svg
@@ -19,8 +21,19 @@ const PuzzleSlotSvg = ({ left, top, size, connectors }) => {
         viewBox={`${-pad} ${-pad} ${size + 2 * pad} ${size + 2 * pad}`}
         style={{ position: 'absolute', left: -pad, top: -pad }}
       >
-        {/* Soft filled slot so neighboring insets visually interlock */}
-        <Path d={d} fill="rgba(255,255,255,0.18)" stroke={themeVariables.primaryColor} strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+        <Defs>
+          <LinearGradient id={gradId} x1="0" y1="0" x2="1" y2="1">
+            <Stop offset="0%" stopColor="#e0e0e0" />
+            <Stop offset="100%" stopColor="#f9f9f9" />
+          </LinearGradient>
+          <ClipPath id={clipId}>
+            <Path d={d} />
+          </ClipPath>
+        </Defs>
+        <Path d={d} fill={`url(#${gradId})`} stroke="rgba(0,0,0,0.15)" strokeWidth={1} />
+        <G clipPath={`url(#${clipId})`}>
+          <Path d={d} fill="none" stroke="rgba(0,0,0,0.25)" strokeWidth={2} />
+        </G>
       </Svg>
     </View>
   );
@@ -30,6 +43,13 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     overflow: 'visible',
+  },
+  shadow: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 1,
+    elevation: 1,
   },
 });
 


### PR DESCRIPTION
## Summary
- render entire quote in ShapeBuilderGame with connected slots
- add shadowed jigsaw pieces and inset slot shading

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useEffect has missing dependencies, jest not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689ac17a44108328baff08154a3f9803